### PR TITLE
Only persist files that were sent to the server

### DIFF
--- a/src/components/main/index.js
+++ b/src/components/main/index.js
@@ -1,6 +1,8 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
 
+import { UPLOAD_STATUSES } from "config";
+
 import uploadActions from "../../redux/actions/upload-actions";
 import downloadActions from "../../redux/actions/download-actions";
 
@@ -18,11 +20,14 @@ const mapDispatchToProps = dispatch => ({
 
 class Main extends Component {
   renderUploadRow(upload, downloadFileFn) {
-    const { fileName, uploadProgress, handle, numberOfChunks } = upload;
+    const { fileName, uploadProgress, handle, numberOfChunks, status } = upload;
     if (uploadProgress < 100) {
       return (
         <p key={handle}>
-          {fileName}: UPLOAD PROGRESS: {uploadProgress}%
+          {fileName}:{" "}
+          {status === UPLOAD_STATUSES.FAILED
+            ? "UPLOAD FAILED, PLEASE TRY AGAIN"
+            : `UPLOAD PROGRESS: ${uploadProgress}%`}
         </p>
       );
     } else {

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,5 +1,7 @@
 export const API = Object.freeze({
   HOST: "http://localhost:8000",
+  // BROKER_NODE_A: "http://localhost:8000",
+  // BROKER_NODE_B: "http://localhost:8000",
   BROKER_NODE_A: "https://broker-1.oysternodes.com",
   BROKER_NODE_B: "https://broker-2.oysternodes.com",
   V1_UPLOAD_SESSIONS_PATH: "/api/v1/upload-sessions"
@@ -8,6 +10,12 @@ export const API = Object.freeze({
 export const IOTA_API = Object.freeze({
   PROVIDER: "http://eugene.iota.community:14265",
   ADDRESS_LENGTH: 81
+});
+
+export const UPLOAD_STATUSES = Object.freeze({
+  PENDING: "PENDING",
+  SENT: "SENT",
+  FAILED: "FAILED"
 });
 
 export const FILE = Object.freeze({

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import "index.css";
 import { store, persistor } from "./redux";
 import Root from "./components/root";
 import registerServiceWorker from "./register-service-worker";
-persistor.purge();
+// persistor.purge();
 
 const App = () => (
   <Provider store={store}>

--- a/src/redux/actions/upload-actions.js
+++ b/src/redux/actions/upload-actions.js
@@ -39,9 +39,9 @@ const ACTIONS = Object.freeze({
     type: ACTIONS.UPLOAD_SUCCESS,
     payload: { numberOfChunks, handle, fileName }
   }),
-  uploadFailureAction: error => ({
+  uploadFailureAction: handle => ({
     type: ACTIONS.UPLOAD_FAILURE,
-    payload: error
+    payload: handle
   }),
   updateUploadProgress: ({ handle, uploadProgress }) => ({
     type: ACTIONS.UPDATE_UPLOAD_PROGRESS,

--- a/src/redux/actions/upload-actions.js
+++ b/src/redux/actions/upload-actions.js
@@ -6,6 +6,8 @@ const UPLOAD_SUCCESS = "oyster/upload/upload_success";
 const UPLOAD_FAILURE = "oyster/upload/upload_failure";
 const UPDATE_UPLOAD_PROGRESS = "oyster/upload/update_upload_progress";
 const MARK_UPLOAD_AS_COMPLETE = "oyster/upload/mark_upload_as_complete";
+const REFRESH_INCOMPLETE_UPLOADS = "oyster/upload/refresh_incomplete_uploads";
+const POLL_UPLOAD_PROGRESS = "oyster/upload/poll_upload_progress";
 
 const ACTIONS = Object.freeze({
   // actions
@@ -17,6 +19,8 @@ const ACTIONS = Object.freeze({
   UPLOAD_FAILURE,
   UPDATE_UPLOAD_PROGRESS,
   MARK_UPLOAD_AS_COMPLETE,
+  REFRESH_INCOMPLETE_UPLOADS,
+  POLL_UPLOAD_PROGRESS,
 
   // actionCreators
   initializeUploadAction: file => ({
@@ -50,6 +54,13 @@ const ACTIONS = Object.freeze({
   markUploadAsComplete: handle => ({
     type: ACTIONS.MARK_UPLOAD_AS_COMPLETE,
     payload: handle
+  }),
+  refreshIncompleteUploads: () => ({
+    type: ACTIONS.REFRESH_INCOMPLETE_UPLOADS
+  }),
+  pollUploadProgress: ({ handle, numberOfChunks }) => ({
+    type: ACTIONS.POLL_UPLOAD_PROGRESS,
+    payload: { handle, numberOfChunks }
   })
 });
 

--- a/src/redux/epics/upload-epic.js
+++ b/src/redux/epics/upload-epic.js
@@ -44,10 +44,7 @@ const uploadFile = (action$, store) => {
       .map(({ numberOfChunks, handle, fileName }) =>
         uploadActions.uploadSuccessAction({ numberOfChunks, handle, fileName })
       )
-      .catch(error => {
-        console.log("UPLOAD FILE EPIC ERROR: ", error);
-        return uploadActions.uploadFailureAction;
-      });
+      .catch(() => Observable.of(uploadActions.uploadFailureAction(handle)));
   });
 };
 

--- a/src/redux/index.js
+++ b/src/redux/index.js
@@ -7,6 +7,7 @@ import storage from "redux-persist/lib/storage";
 import { UPLOAD_STATUSES } from "config";
 import epics from "redux/epics";
 import reducer from "redux/reducers";
+import uploadActions from "redux/actions/upload-actions";
 
 const composeFn = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 const middleware = [
@@ -36,4 +37,6 @@ export const store = createStore(
   composeFn(applyMiddleware(...middleware))
 );
 
-export const persistor = persistStore(store);
+export const persistor = persistStore(store, {}, () => {
+  store.dispatch(uploadActions.refreshIncompleteUploads());
+});

--- a/src/redux/index.js
+++ b/src/redux/index.js
@@ -1,9 +1,10 @@
 import { applyMiddleware, compose, createStore } from "redux";
 import { createLogger } from "redux-logger";
 import { createEpicMiddleware } from "redux-observable";
-import { persistReducer, persistStore } from "redux-persist";
+import { persistReducer, persistStore, createTransform } from "redux-persist";
 import storage from "redux-persist/lib/storage";
 
+import { UPLOAD_STATUSES } from "config";
 import epics from "redux/epics";
 import reducer from "redux/reducers";
 
@@ -13,10 +14,21 @@ const middleware = [
   createEpicMiddleware(epics)
 ];
 
+const uploadTransform = createTransform(
+  inboundState => inboundState,
+  outboundState => {
+    const { history } = outboundState;
+    const sentFiles = history.filter(f => f.status === UPLOAD_STATUSES.SENT);
+    return { ...outboundState, history: sentFiles };
+  },
+  { whitelist: ["upload"] }
+);
+
 const persistConfig = {
   key: "oyster",
   storage: storage,
-  whitelist: ["upload"]
+  whitelist: ["upload"],
+  transforms: [uploadTransform]
 };
 
 export const store = createStore(

--- a/src/redux/index.js
+++ b/src/redux/index.js
@@ -28,7 +28,7 @@ const uploadTransform = createTransform(
 const persistConfig = {
   key: "oyster",
   storage: storage,
-  whitelist: ["upload"],
+  whitelist: [],
   transforms: [uploadTransform]
 };
 

--- a/src/redux/reducers/upload-reducer.js
+++ b/src/redux/reducers/upload-reducer.js
@@ -1,13 +1,20 @@
 import uploadActions from "redux/actions/upload-actions";
+import { UPLOAD_STATUSES } from "config";
 
 const initState = {
   history: [
-    // { numberOfChunks: 10, fileName: "hello.txt", handle: "abc123", uploadProgress: 0 }
+    // object returned by uploadedFileGenerator()
   ]
 };
 
 const uploadedFileGenerator = ({ numberOfChunks, fileName, handle }) => {
-  return { numberOfChunks, fileName, handle, uploadProgress: 0 };
+  return {
+    numberOfChunks,
+    fileName,
+    handle,
+    uploadProgress: 0,
+    status: UPLOAD_STATUSES.PENDING
+  };
 };
 
 const uploadReducer = (state = initState, action) => {
@@ -31,6 +38,31 @@ const uploadReducer = (state = initState, action) => {
           uploadedFileGenerator({ numberOfChunks, fileName, handle })
         ]
       };
+
+    case uploadActions.UPLOAD_SUCCESS:
+      const { handle: succeededHandle } = action.payload;
+      const newHistory = state.history.map(f => {
+        return f.handle === succeededHandle
+          ? { ...f, status: UPLOAD_STATUSES.SENT }
+          : f;
+      });
+      return {
+        ...state,
+        history: newHistory
+      };
+
+    case uploadActions.UPLOAD_FAILURE:
+      const failedHandle = action.payload;
+      const h = state.history.map(f => {
+        return f.handle === failedHandle
+          ? { ...f, status: UPLOAD_STATUSES.FAILED }
+          : f;
+      });
+      return {
+        ...state,
+        history: h
+      };
+
     default:
       return state;
   }


### PR DESCRIPTION
- Remove from upload history if the file was 1) never sent 2) sent unsuccessfully
- On app start, poll IOTA for the files that were SENT && uploadProgress < 100
- (Just looked at designs for testnet A) Temporarily remove persistent of upload history