### PR TITLE
File validator

### DIFF
--- a/src/components/playground/index.js
+++ b/src/components/playground/index.js
@@ -1,0 +1,38 @@
+import React, { Component } from "react";
+import { connect } from "react-redux";
+
+import playgroundActions from "redux/actions/playground-actions";
+import PrimaryButton from "components/shared/primary-button";
+
+const mapStateToProps = state => ({});
+const mapDispatchToProps = dispatch => ({
+  testUploadFn: file => dispatch(playgroundActions.testUploadAction(file))
+});
+
+class Playground extends Component {
+  render() {
+    const { testUploadFn } = this.props;
+    return (
+      <div>
+        <h1>PLAYGROUND</h1>
+        <input ref="fileInput" type="file" required />
+        <PrimaryButton
+          className="btn btn-upload"
+          type="button"
+          onClick={() => {
+            const file = this.refs.fileInput.files[0];
+            if (!file) {
+              alert("Please select a file.");
+            } else {
+              testUploadFn(file);
+            }
+          }}
+        >
+          Upload and then Download
+        </PrimaryButton>
+      </div>
+    );
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Playground);

--- a/src/components/upload-started/upload-started-slide.js
+++ b/src/components/upload-started/upload-started-slide.js
@@ -21,8 +21,8 @@ const UploadStartedSlide = ({ uploadProgress }) => (
         className="upload-progress-bar"
       />
       <p>
-        {Math.min(100, uploadProgress)}% - File is being broken into chunks and
-        each chunk encrypted…
+        {Math.round(Math.min(100, uploadProgress))}% - File is being broken into
+        chunks and each chunk encrypted…
       </p>
     </div>
   </Slide>

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -9,7 +9,9 @@ export const API = Object.freeze({
 });
 
 export const IOTA_API = Object.freeze({
-  PROVIDER: "http://eugene.iota.community:14265",
+  PROVIDER_A: "http://eugene.iota.community:14265",
+  PROVIDER_B: "http://eugene.iotasupport.com:14999",
+  PROVIDER_C: "http://eugeneoldisoft.iotasupport.com:14265",
   ADDRESS_LENGTH: 81
 });
 

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -22,5 +22,5 @@ export const UPLOAD_STATUSES = Object.freeze({
 });
 
 export const FILE = Object.freeze({
-  CHUNK_BYTE_SIZE: 1000
+  CHUNK_BYTE_SIZE: 500
 });

--- a/src/index.js
+++ b/src/index.js
@@ -18,8 +18,6 @@ import UploadComplete from "components/upload-complete";
 import Playground from "components/playground";
 import registerServiceWorker from "./register-service-worker";
 
-const __DEV__ = !process.env || process.env.NODE_ENV === "development";
-
 const App = () => (
   <Provider store={store}>
     <PersistGate loading={null} persistor={persistor}>
@@ -32,8 +30,9 @@ const App = () => (
           <Route path="/download-complete" component={DownloadComplete} />
           <Route path="/upload-form" component={UploadForm} />
           <Route path="/upload-started" component={UploadStarted} />
-          {__DEV__ ? <Route path="/playground" component={Playground} /> : null}
           <Route path="/upload-complete" component={UploadComplete} />
+
+          <Route path="/playground" component={Playground} />
         </div>
       </ConnectedRouter>
     </PersistGate>

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,10 @@ import DownloadComplete from "components/download-complete";
 import UploadForm from "components/upload-form";
 import UploadStarted from "components/upload-started";
 import UploadComplete from "components/upload-complete";
+import Playground from "components/playground";
 import registerServiceWorker from "./register-service-worker";
+
+const __DEV__ = !process.env || process.env.NODE_ENV === "development";
 
 const App = () => (
   <Provider store={store}>
@@ -29,6 +32,7 @@ const App = () => (
           <Route path="/download-complete" component={DownloadComplete} />
           <Route path="/upload-form" component={UploadForm} />
           <Route path="/upload-started" component={UploadStarted} />
+          {__DEV__ ? <Route path="/playground" component={Playground} /> : null}
           <Route path="/upload-complete" component={UploadComplete} />
         </div>
       </ConnectedRouter>

--- a/src/redux/actions/playground-actions.js
+++ b/src/redux/actions/playground-actions.js
@@ -1,0 +1,20 @@
+const TEST_UPLOAD = "oyster/playground/test_upload";
+const TEST_DOWNLOAD = "oyster/playground/test_download";
+
+const ACTIONS = Object.freeze({
+  // actions
+  TEST_UPLOAD,
+  TEST_DOWNLOAD,
+
+  // actionCreators
+  testUploadAction: file => ({
+    type: ACTIONS.TEST_UPLOAD,
+    payload: file
+  }),
+  testDownloadAction: ({ chunksInTrytes, handle, fileName }) => ({
+    type: ACTIONS.TEST_DOWNLOAD,
+    payload: { chunksInTrytes, handle, fileName }
+  })
+});
+
+export default ACTIONS;

--- a/src/redux/epics/download-epic.js
+++ b/src/redux/epics/download-epic.js
@@ -1,7 +1,6 @@
 import { Observable } from "rxjs";
 import { combineEpics } from "redux-observable";
 import _ from "lodash";
-import Base64 from "base64-arraybuffer";
 import FileSaver from "file-saver";
 
 import downloadActions from "redux/actions/download-actions";

--- a/src/redux/epics/download-epic.js
+++ b/src/redux/epics/download-epic.js
@@ -63,6 +63,10 @@ const beginDownload = (action$, store) => {
         const completeFileArrayBuffer = FileProcessor.mergeArrayBuffers(
           chunksArrayBuffers
         );
+        console.log(
+          "DOWNLOADED ARRAY BUFFER: ",
+          new Uint8Array(completeFileArrayBuffer)
+        );
 
         const blob = new Blob([new Uint8Array(completeFileArrayBuffer)]);
         FileSaver.saveAs(blob, fileName);

--- a/src/redux/epics/download-epic.js
+++ b/src/redux/epics/download-epic.js
@@ -3,6 +3,7 @@ import { combineEpics } from "redux-observable";
 import _ from "lodash";
 import FileSaver from "file-saver";
 
+import { IOTA_API } from "config";
 import downloadActions from "redux/actions/download-actions";
 import Iota from "services/iota";
 import Datamap from "utils/datamap";
@@ -49,7 +50,9 @@ const beginDownload = (action$, store) => {
   return action$.ofType(downloadActions.BEGIN_DOWNLOAD).mergeMap(action => {
     const { handle, fileName, numberOfChunks } = action.payload;
     const datamap = Datamap.generate(handle, numberOfChunks);
-    const addresses = _.values(datamap).map(Iota.toAddress);
+    const addresses = _.values(datamap).map(trytes =>
+      trytes.substr(0, IOTA_API.ADDRESS_LENGTH)
+    );
     const nonMetaDataAddresses = addresses.slice(1, addresses.length);
 
     return Observable.fromPromise(Iota.findTransactions(nonMetaDataAddresses))

--- a/src/redux/epics/download-epic.js
+++ b/src/redux/epics/download-epic.js
@@ -63,7 +63,8 @@ const beginDownload = (action$, store) => {
         const completeFileArrayBuffer = FileProcessor.mergeArrayBuffers(
           chunksArrayBuffers
         );
-        const blob = new Blob(completeFileArrayBuffer);
+
+        const blob = new Blob([new Uint8Array(completeFileArrayBuffer)]);
         FileSaver.saveAs(blob, fileName);
 
         return downloadActions.downloadSuccessAction();

--- a/src/redux/epics/index.js
+++ b/src/redux/epics/index.js
@@ -3,5 +3,11 @@ import { combineEpics } from "redux-observable";
 import uploadEpic from "redux/epics/upload-epic";
 import downloadEpic from "redux/epics/download-epic";
 import navigationEpic from "redux/epics/navigation-epic";
+import playgroundEpic from "redux/epics/playground-epic";
 
-export default combineEpics(uploadEpic, downloadEpic, navigationEpic);
+export default combineEpics(
+  uploadEpic,
+  downloadEpic,
+  navigationEpic,
+  playgroundEpic
+);

--- a/src/redux/epics/playground-epic.js
+++ b/src/redux/epics/playground-epic.js
@@ -1,0 +1,74 @@
+import { Observable } from "rxjs";
+import { combineEpics } from "redux-observable";
+import _ from "lodash";
+import FileSaver from "file-saver";
+
+import playgroundActions from "redux/actions/playground-actions";
+import downloadActions from "redux/actions/download-actions";
+
+import { FILE } from "config";
+import Iota from "services/iota";
+import Datamap from "utils/datamap";
+import FileProcessor from "utils/file-processor";
+
+const testUpload = (action$, store) => {
+  return action$.ofType(playgroundActions.TEST_UPLOAD).mergeMap(action => {
+    const file = action.payload;
+
+    const { numberOfChunks, handle, fileName } = FileProcessor.initializeUpload(
+      file
+    );
+
+    const byteChunks = FileProcessor.createByteChunks(file.size);
+
+    const chunkReads = byteChunks.map(
+      byte =>
+        new Promise((resolve, reject) => {
+          const { chunkIdx, chunkStartingPoint } = byte;
+          const blob = file.slice(
+            chunkStartingPoint,
+            chunkStartingPoint + FILE.CHUNK_BYTE_SIZE
+          );
+          const reader = FileProcessor.createReader(arrayBuffer => {
+            const chunkInTrytes = FileProcessor.chunkToIotaFormat(
+              arrayBuffer,
+              handle
+            );
+            resolve(chunkInTrytes);
+          });
+          reader.readAsArrayBuffer(blob);
+        })
+    );
+
+    return Observable.fromPromise(Promise.all(chunkReads))
+      .map(chunksInTrytes => {
+        console.log("CHUNKS IN TRYTES: ", chunksInTrytes);
+        return playgroundActions.testDownloadAction({
+          chunksInTrytes,
+          handle,
+          fileName
+        });
+      })
+      .catch(error => {
+        console.log("ERROR: ", error);
+        return Observable.empty();
+      });
+  });
+};
+
+const testDownload = (action$, store) => {
+  return action$.ofType(playgroundActions.TEST_DOWNLOAD).map(action => {
+    const { chunksInTrytes, handle, fileName } = action.payload;
+    const decryptedChunks = chunksInTrytes.map(trytes => {
+      return FileProcessor.chunkFromIotaFormat(trytes, handle);
+    });
+
+    const arrayBuffer = _.flatten(decryptedChunks);
+    const blob = new Blob(arrayBuffer);
+    FileSaver.saveAs(blob, fileName);
+
+    return downloadActions.downloadSuccessAction();
+  });
+};
+
+export default combineEpics(testUpload, testDownload);

--- a/src/services/iota.js
+++ b/src/services/iota.js
@@ -53,7 +53,13 @@ const findTransactions = addresses =>
         }
         const settledTransactions = transactionObjects || [];
         const uniqTransactions = _.uniqBy(settledTransactions, "address");
-        resolve(uniqTransactions);
+
+        console.log("IOTA TRANSACTIONS FOUND: ", uniqTransactions);
+        if (uniqTransactions.length === addresses.length) {
+          resolve(uniqTransactions);
+        } else {
+          reject();
+        }
       }
     );
   });

--- a/src/services/iota.js
+++ b/src/services/iota.js
@@ -2,8 +2,18 @@ import IOTA from "iota.lib.js";
 import _ from "lodash";
 import { IOTA_API } from "config";
 
-const Iota = new IOTA({
-  provider: IOTA_API.PROVIDER
+const Iota = new IOTA();
+
+const IotaA = new IOTA({
+  provider: IOTA_API.PROVIDER_A
+});
+
+const IotaB = new IOTA({
+  provider: IOTA_API.PROVIDER_B
+});
+
+const IotaC = new IOTA({
+  provider: IOTA_API.PROVIDER_C
 });
 
 const toAddress = string => string.substr(0, IOTA_API.ADDRESS_LENGTH);
@@ -27,9 +37,9 @@ const parseMessage = message => {
   return Iota.utils.fromTrytes(evenChars);
 };
 
-const checkUploadPercentage = addresses =>
+const queryTransactions = (iotaProvider, addresses) =>
   new Promise((resolve, reject) => {
-    Iota.api.findTransactionObjects(
+    iotaProvider.api.findTransactionObjects(
       { addresses },
       (error, transactionObjects) => {
         if (error) {
@@ -37,31 +47,32 @@ const checkUploadPercentage = addresses =>
         }
         const settledTransactions = transactionObjects || [];
         const uniqTransactions = _.uniqBy(settledTransactions, "address");
-        const percentage = uniqTransactions.length / addresses.length * 100;
-        resolve(percentage);
+        resolve(uniqTransactions);
       }
     );
   });
 
+const checkUploadPercentage = addresses =>
+  new Promise((resolve, reject) => {
+    queryTransactions(IotaA, addresses).then(transactions => {
+      const percentage = transactions.length / addresses.length * 100;
+      resolve(percentage);
+    });
+  });
+
 const findTransactions = addresses =>
   new Promise((resolve, reject) => {
-    Iota.api.findTransactionObjects(
-      { addresses },
-      (error, transactionObjects) => {
-        if (error) {
-          console.log("IOTA ERROR: ", error);
-        }
-        const settledTransactions = transactionObjects || [];
-        const uniqTransactions = _.uniqBy(settledTransactions, "address");
-
-        console.log("IOTA TRANSACTIONS FOUND: ", uniqTransactions);
-        if (uniqTransactions.length === addresses.length) {
-          resolve(uniqTransactions);
-        } else {
-          reject();
-        }
+    Promise.race([
+      queryTransactions(IotaA, addresses),
+      queryTransactions(IotaB, addresses),
+      queryTransactions(IotaC, addresses)
+    ]).then(transactions => {
+      if (transactions.length === addresses.length) {
+        resolve(transactions);
+      } else {
+        reject();
       }
-    );
+    });
   });
 
 export default {

--- a/src/utils/file-processor.js
+++ b/src/utils/file-processor.js
@@ -288,5 +288,6 @@ export default {
   metaDataToIotaFormat,
   metaDataFromIotaFormat,
   chunkToIotaFormat,
-  chunkFromIotaFormat
+  chunkFromIotaFormat,
+  createReader
 };

--- a/src/utils/file-processor.js
+++ b/src/utils/file-processor.js
@@ -14,7 +14,7 @@ const {
 } = Encryption;
 
 const axiosInstance = axios.create({
-  timeout: 100000,
+  timeout: 200000,
   headers: {
     "Access-Control-Allow-Origin": "*"
   }
@@ -92,19 +92,13 @@ const uploadFileToBrokerNodes = (file, handle) => {
   const genesisHash = sha256(handle);
 
   return Promise.all([
-    createUploadSession(API.BROKER_NODE_A, file.size, genesisHash),
-    createUploadSession(API.BROKER_NODE_B, file.size, genesisHash)
+    createUploadSession(API.BROKER_NODE_A, file.size, genesisHash)
+    // createUploadSession(API.BROKER_NODE_B, file.size, genesisHash)
   ])
     .then(([alphaSessionId, betaSessionId]) =>
       Promise.all([
-        sendToAlphaBroker(
-          alphaSessionId,
-          byteChunks,
-          file,
-          handle,
-          genesisHash
-        ),
-        sendToBetaBroker(betaSessionId, byteChunks, file, handle, genesisHash)
+        sendToAlphaBroker(alphaSessionId, byteChunks, file, handle, genesisHash)
+        // sendToBetaBroker(betaSessionId, byteChunks, file, handle, genesisHash)
       ])
     )
     .then(() => {

--- a/src/utils/file-processor.js
+++ b/src/utils/file-processor.js
@@ -34,9 +34,9 @@ const chunkToIotaFormat = (arrayBuffer, handle) => {
   const encryptedData = Encryption.encrypt(encodedData, handle);
   const trytes = Iota.utils.toTrytes(encryptedData);
 
-  console.log("[UPLOAD] ORIGINAL DATA: ", arrayBuffer);
-  console.log("[UPLOAD] ENCODED DATA: ", encodedData);
-  console.log("[UPLOAD] ENCRYPTED DATA: ", encryptedData);
+  // console.log("[UPLOAD] ORIGINAL DATA: ", new Uint8Array(arrayBuffer));
+  // console.log("[UPLOAD] ENCODED DATA: ", encodedData);
+  // console.log("[UPLOAD] ENCRYPTED DATA: ", encryptedData);
   return trytes;
 };
 
@@ -45,9 +45,9 @@ const chunkFromIotaFormat = (trytes, handle) => {
   const encodedData = Encryption.decrypt(encryptedData, handle);
   const arrayBuffer = Base64.decode(encodedData);
 
-  console.log("[DOWNLOAD] ENCRYPTED DATA: ", encryptedData);
-  console.log("[DOWNLOAD] ENCODED DATA: ", encodedData);
-  console.log("[DOWNLOAD] ORIGINAL DATA: ", arrayBuffer);
+  // console.log("[DOWNLOAD] ENCRYPTED DATA: ", encryptedData);
+  // console.log("[DOWNLOAD] ENCODED DATA: ", encodedData);
+  // console.log("[DOWNLOAD] ORIGINAL DATA: ", new Uint8Array(arrayBuffer));
   return arrayBuffer;
 };
 


### PR DESCRIPTION
- adds /playground route for testing tangle-less chunking / reassembling
- decreases chunk size to 500 bytes, since encoding / encrypting seems to increase the message size to >1kb
- only send to 1 broker
- download from 3 different IOTA nodes
- fixes ordering of transactions
- fixes merging of array buffers