### PR TITLE
Increased amount of data a chunk can hold.

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,40 +1,40 @@
 export const API = Object.freeze({
-  // HOST: "http://localhost:8000",
-  // BROKER_NODE_A: "http://localhost:8000",
-  // BROKER_NODE_B: "http://localhost:8000",
-  HOST: "https://broker-1.oysternodes.com",
-  BROKER_NODE_A: "https://broker-1.oysternodes.com",
-  BROKER_NODE_B: "https://broker-2.oysternodes.com",
-  V1_UPLOAD_SESSIONS_PATH: "/api/v1/upload-sessions",
-  V2_UPLOAD_SESSIONS_PATH: "/api/v2/upload-sessions",
-  CHUNKS_PER_REQUEST: 10
+    // HOST: "http://localhost:8000",
+    // BROKER_NODE_A: "http://localhost:8000",
+    // BROKER_NODE_B: "http://localhost:8000",
+    HOST: "",
+    BROKER_NODE_A: "",
+    BROKER_NODE_B: "",
+    V1_UPLOAD_SESSIONS_PATH: ":3000/api/v1/upload-sessions",
+    V2_UPLOAD_SESSIONS_PATH: ":3000/api/v2/upload-sessions",
+    CHUNKS_PER_REQUEST: 10
 });
 
 export const IOTA_API = Object.freeze({
-  PROVIDER_A: "http://18.188.17.130:14265",
-  PROVIDER_B: "http://18.220.1.63:14265",
-  PROVIDER_C: "http://18.216.90.80:14265",
-  ADDRESS_LENGTH: 81,
-  MESSAGE_LENGTH: 2187
+    PROVIDER_A: "http://18.188.17.130:14265",
+    PROVIDER_B: "http://18.220.1.63:14265",
+    PROVIDER_C: "http://18.216.90.80:14265",
+    ADDRESS_LENGTH: 81,
+    MESSAGE_LENGTH: 2187
 });
 
 export const UPLOAD_STATUSES = Object.freeze({
-  PENDING: "PENDING",
-  SENT: "SENT",
-  FAILED: "FAILED"
+    PENDING: "PENDING",
+    SENT: "SENT",
+    FAILED: "FAILED"
 });
 
 export const DOWNLOAD_STATUSES = Object.freeze({
-  STANDBY: "STANDBY",
-  PENDING: "PENDING",
-  RECEIVED: "RECEIVED",
-  FAILED: "FAILED"
+    STANDBY: "STANDBY",
+    PENDING: "PENDING",
+    RECEIVED: "RECEIVED",
+    FAILED: "FAILED"
 });
 
 export const FILE = Object.freeze({
-  MAX_FILE_SIZE: 200 * 1000,
-  CHUNK_TYPES: {
-    METADATA: "METADATA",
-    FILE_CONTENTS: "FILE_CONTENTS"
-  }
+    MAX_FILE_SIZE: 200 * 1000,
+    CHUNK_TYPES: {
+        METADATA: "METADATA",
+        FILE_CONTENTS: "FILE_CONTENTS"
+    }
 });

--- a/src/redux/epics/download-epic.js
+++ b/src/redux/epics/download-epic.js
@@ -68,14 +68,14 @@ const beginDownload = (action$, store) => {
           .map(tx => tx.signatureMessageFragment)
           .join("");
 
-        const decryptedFileArrayBuffer = FileProcessor.decryptFile(
+        const bytesArray = FileProcessor.decryptFile(
           encryptedFileContents,
           handle
         );
 
-        console.log("DOWNLOADED ARRAY BUFFER", decryptedFileArrayBuffer);
+        console.log("DOWNLOADED BYTES ARRAY", bytesArray);
 
-        const blob = new Blob([new Uint8Array(decryptedFileArrayBuffer)]);
+        const blob = new Blob([new Uint8Array(bytesArray)]);
         FileSaver.saveAs(blob, fileName);
 
         return downloadActions.downloadSuccessAction();

--- a/src/redux/epics/playground-epic.js
+++ b/src/redux/epics/playground-epic.js
@@ -1,58 +1,58 @@
-import { Observable } from "rxjs";
-import { combineEpics } from "redux-observable";
+import {Observable} from "rxjs";
+import {combineEpics} from "redux-observable";
 import FileSaver from "file-saver";
 
 import playgroundActions from "redux/actions/playground-actions";
 import downloadActions from "redux/actions/download-actions";
 
-import { FILE, IOTA_API } from "config";
+import {FILE, IOTA_API} from "config";
 import FileProcessor from "utils/file-processor";
 
 const testUpload = (action$, store) => {
-  return action$.ofType(playgroundActions.TEST_UPLOAD).mergeMap(action => {
-    const file = action.payload;
-    return Observable.fromPromise(FileProcessor.initializeUpload(file))
-      .map(({ numberOfChunks, handle, fileName, data }) => {
-        const byteChunks = FileProcessor.createByteChunks(data.length);
-        const chunksInTrytes = byteChunks
-          .filter(b => b.type === FILE.CHUNK_TYPES.FILE_CONTENTS)
-          .map(byte => {
-            const { startingPoint } = byte;
-            return data.slice(
-              startingPoint,
-              startingPoint + IOTA_API.MESSAGE_LENGTH
-            );
-          });
-        return playgroundActions.testDownloadAction({
-          chunksInTrytes,
-          handle,
-          fileName
-        });
-      })
-      .catch(error => {
-        console.log("ERROR: ", error);
-        return Observable.empty();
-      });
-  });
+    return action$.ofType(playgroundActions.TEST_UPLOAD).mergeMap(action => {
+        const file = action.payload;
+        return Observable.fromPromise(FileProcessor.initializeUpload(file))
+            .map(({numberOfChunks, handle, fileName, data}) => {
+                const byteChunks = FileProcessor.createByteChunks(data.length);
+                const chunksInTrytes = byteChunks
+                    .filter(b => b.type === FILE.CHUNK_TYPES.FILE_CONTENTS)
+                    .map(byte => {
+                        const {startingPoint} = byte;
+                        return data.slice(
+                            startingPoint,
+                            startingPoint + IOTA_API.MESSAGE_LENGTH
+                        );
+                    });
+                return playgroundActions.testDownloadAction({
+                    chunksInTrytes,
+                    handle,
+                    fileName
+                });
+            })
+            .catch(error => {
+                console.log("ERROR: ", error);
+                return Observable.empty();
+            });
+    });
 };
 
 const testDownload = (action$, store) => {
-  return action$.ofType(playgroundActions.TEST_DOWNLOAD).map(action => {
-    const { chunksInTrytes, handle, fileName } = action.payload;
-    const encryptedFileContents = chunksInTrytes.join("");
+    return action$.ofType(playgroundActions.TEST_DOWNLOAD).map(action => {
+        const {chunksInTrytes, handle, fileName} = action.payload;
+        const encryptedFileContents = chunksInTrytes.join("");
 
-    const decryptedFileArrayBuffer = FileProcessor.decryptFile(
-      encryptedFileContents,
-      handle
-    );
+        const bytesArray = FileProcessor.decryptFile(
+            encryptedFileContents,
+            handle
+        );
 
-    console.log("DOWNLOADED ARRAY BUFFER", decryptedFileArrayBuffer);
+        console.log("DOWNLOADED BYTES ARRAY", bytesArray);
 
-    const blob = new Blob([new Uint8Array(decryptedFileArrayBuffer)]);
-    FileSaver.saveAs(blob, fileName);
+        const blob = new Blob([new Uint8Array(bytesArray)]);
+        FileSaver.saveAs(blob, fileName);
 
-    return downloadActions.downloadSuccessAction();
-  });
+        return downloadActions.downloadSuccessAction();
+    });
 };
 
 export default combineEpics(testUpload, testDownload);

--- a/src/utils/encryption.js
+++ b/src/utils/encryption.js
@@ -2,52 +2,115 @@ import CryptoJS from "crypto-js";
 import uuidv4 from "uuid/v4";
 
 const parseEightCharsOfFilename = fileName => {
-  fileName = fileName + "________";
-  fileName = fileName.substr(0, 8);
+    fileName = fileName + "________";
+    fileName = fileName.substr(0, 8);
 
-  return fileName;
+    return fileName;
 };
 
 const getSalt = numChars => {
-  const salt = Math.random()
-    .toString(36)
-    .substr(2, numChars);
+    const salt = Math.random()
+        .toString(36)
+        .substr(2, numChars);
 
-  return salt;
+    return salt;
 };
 
 const getPrimordialHash = () => {
-  const entropy = uuidv4();
-  return CryptoJS.SHA256(entropy).toString();
+    const entropy = uuidv4();
+    return CryptoJS.SHA256(entropy).toString();
 };
 
 // Returns [obfuscatedHash, nextHash]
 const hashChain = hash => {
-  const obfuscatedHash = CryptoJS.SHA384(hash).toString();
-  const nextHash = CryptoJS.SHA256(hash).toString();
+    const obfuscatedHash = CryptoJS.SHA384(hash).toString();
+    const nextHash = CryptoJS.SHA256(hash).toString();
 
-  return [obfuscatedHash, nextHash];
+    return [obfuscatedHash, nextHash];
 };
 
 // Genesis hash is not yet obfuscated.
 const genesisHash = handle => {
-  const [_obfuscatedHash, genHash] = hashChain(handle);
+    const [_obfuscatedHash, genHash] = hashChain(handle);
 
-  return genHash;
+    return genHash;
 };
 
-const encrypt = (text, secretKey) =>
-  CryptoJS.AES.encrypt(text, secretKey).toString();
+const byteArrayToWordArray = (ba) => {
+    let wa = [], i;
+    for (i = 0; i < ba.length; i++) {
+        wa[(i / 4) | 0] |= ba[i] << (24 - 8 * i);
+    }
+
+    return CryptoJS.lib.WordArray.create(wa, ba.length);
+};
+
+const wordArrayToByteArray = (wordArray, length) => {
+    if (wordArray.hasOwnProperty("sigBytes") && wordArray.hasOwnProperty("words")) {
+        length = wordArray.sigBytes;
+        wordArray = wordArray.words;
+    }
+
+    let result = [],
+        bytes,
+        i = 0;
+    while (length > 0) {
+        bytes = wordToByteArray(wordArray[i], Math.min(4, length));
+        length -= bytes.length;
+        result.push(bytes);
+        i++;
+    }
+    return [].concat.apply([], result);
+};
+
+const wordToByteArray = (word, length) => {
+    let ba = [],
+        xFF = 0xFF;
+    if (length > 0)
+        ba.push(word >>> 24);
+    if (length > 1)
+        ba.push((word >>> 16) & xFF);
+    if (length > 2)
+        ba.push((word >>> 8) & xFF);
+    if (length > 3)
+        ba.push(word & xFF);
+
+    return ba;
+};
+
+function string2Bin(str) {
+    var result = [];
+    for (var i = 0; i < str.length; i++) {
+        result.push(str.charCodeAt(i));
+    }
+    return result;
+}
+
+function bin2String(array) {
+    return String.fromCharCode.apply(String, array);
+}
+
+const encrypt = (byteArray, secretKey) =>
+    CryptoJS.Rabbit.encrypt(byteArrayToWordArray(byteArray), secretKey).toString();
 
 const decrypt = (text, secretKey) =>
-  CryptoJS.AES.decrypt(text, secretKey).toString(CryptoJS.enc.Utf8);
+    wordArrayToByteArray(CryptoJS.Rabbit.decrypt(text, secretKey));
+
+const encryptMetaData = (text, secretKey) =>
+    CryptoJS.AES.encrypt(text, secretKey).toString();
+
+const decryptMetaData = (text, secretKey) =>
+    CryptoJS.AES.decrypt(text, secretKey).toString(CryptoJS.enc.Utf8);
+
 
 export default {
-  parseEightCharsOfFilename,
-  getSalt,
-  getPrimordialHash,
-  hashChain,
-  genesisHash,
-  encrypt,
-  decrypt
+    parseEightCharsOfFilename,
+    getSalt,
+    getPrimordialHash,
+    hashChain,
+    genesisHash,
+    encrypt,
+    decrypt,
+    decryptMetaData,
+    encryptMetaData,
 };

--- a/src/utils/file-processor.js
+++ b/src/utils/file-processor.js
@@ -3,159 +3,156 @@ import Encryption from "utils/encryption";
 import Base64 from "base64-arraybuffer";
 
 import Iota from "services/iota";
-import { FILE, IOTA_API } from "config";
+import {FILE, IOTA_API} from "config";
 
 const metaDataToIotaFormat = (object, handle) => {
-  const metaDataString = JSON.stringify(object);
-  const encryptedData = Encryption.encrypt(metaDataString, handle);
-  const trytes = Iota.utils.toTrytes(encryptedData);
+    const metaDataString = JSON.stringify(object);
+    const encryptedData = Encryption.encryptMetaData(metaDataString, handle);
+    const trytes = Iota.utils.toTrytes(encryptedData);
 
-  return trytes;
+    return trytes;
 };
 
 const metaDataFromIotaFormat = (trytes, handle) => {
-  const encryptedData = Iota.parseMessage(trytes);
-  const decryptedData = Encryption.decrypt(encryptedData, handle);
-  const metaData = JSON.parse(decryptedData);
+    const encryptedData = Iota.parseMessage(trytes);
+    const decryptedData = Encryption.decryptMetaData(encryptedData, handle);
+    const metaData = JSON.parse(decryptedData);
 
-  return metaData;
+    return metaData;
 };
 
 const encryptFile = (file, handle) =>
-  readBlob(file).then(arrayBuffer => {
-    const encodedData = Base64.encode(arrayBuffer);
-    const encryptedData = Encryption.encrypt(encodedData, handle);
-    const trytes = Iota.utils.toTrytes(encryptedData);
+    readBlob(file).then(arrayBuffer => {
+        const bytes = new Uint8Array(arrayBuffer);
+        const encryptedData = Encryption.encrypt(bytes, handle);
+        const trytes = Iota.utils.toTrytes(encryptedData);
 
-    // console.log("[UPLOAD] ENCRYPTED FILE: ", trytes);
-    return trytes;
-  });
+        // console.log("[UPLOAD] ENCRYPTED FILE: ", trytes);
+        return trytes;
+    });
 
 const decryptFile = (trytes, handle) => {
-  // console.log("[DOWNLOAD] DECRYPTED FILE: ", trytes);
-  const encryptedData = Iota.parseMessage(trytes);
-  const encodedData = Encryption.decrypt(encryptedData, handle);
-  const arrayBuffer = Base64.decode(encodedData);
+    // console.log("[DOWNLOAD] DECRYPTED FILE: ", trytes);
+    const encryptedData = Iota.parseMessage(trytes);
+    const decryptedData = Encryption.decrypt(encryptedData, handle);
 
-  return arrayBuffer;
+    return decryptedData;
 };
 
-const chunkParamsGenerator = ({ idx, data, hash }) => {
-  return { idx, data, hash };
+const chunkParamsGenerator = ({idx, data, hash}) => {
+    return {idx, data, hash};
 };
 
-const chunkGenerator = ({ idx, startingPoint, type }) => {
-  return { idx, startingPoint, type };
+const chunkGenerator = ({idx, startingPoint, type}) => {
+    return {idx, startingPoint, type};
 };
 
 const initializeUpload = file => {
-  const handle = createHandle(file.name);
-  return encryptFile(file, handle).then(data => {
-    const numberOfChunks = createByteLocations(data.length).length;
-    return { handle, fileName: file.name, numberOfChunks, data };
-  });
+    const handle = createHandle(file.name);
+    return encryptFile(file, handle).then(data => {
+        const numberOfChunks = createByteLocations(data.length).length;
+        return {handle, fileName: file.name, numberOfChunks, data};
+    });
 };
 
 const createHandle = fileName => {
-  const fileNameTrimmed = Encryption.parseEightCharsOfFilename(fileName);
-  const salt = Encryption.getSalt(8);
-  const primordialHash = Encryption.getPrimordialHash();
-  const handle = fileNameTrimmed + primordialHash + salt;
+    const fileNameTrimmed = Encryption.parseEightCharsOfFilename(fileName);
+    const salt = Encryption.getSalt(8);
+    const primordialHash = Encryption.getPrimordialHash();
+    const handle = fileNameTrimmed + primordialHash + salt;
 
-  return handle;
+    return handle;
 };
 
 const createByteLocations = fileSizeBytes =>
-  _.range(0, fileSizeBytes, IOTA_API.MESSAGE_LENGTH);
+    _.range(0, fileSizeBytes, IOTA_API.MESSAGE_LENGTH);
 
 const createByteChunks = fileSizeBytes => {
-  const metaDataChunk = chunkGenerator({
-    idx: 0,
-    startingPoint: null,
-    type: FILE.CHUNK_TYPES.METADATA
-  });
-
-  // This returns an array with the starting byte pointers
-  // ex: For a 2300 byte file it would return: [0, 500, 1000, 1500, 2000]
-  const byteLocations = createByteLocations(fileSizeBytes);
-  const fileContentChunks = _.map(byteLocations, (byte, index) => {
-    return chunkGenerator({
-      idx: index + 1,
-      startingPoint: byte,
-      type: FILE.CHUNK_TYPES.FILE_CONTENTS
+    const metaDataChunk = chunkGenerator({
+        idx: 0,
+        startingPoint: null,
+        type: FILE.CHUNK_TYPES.METADATA
     });
-  });
 
-  return [metaDataChunk, ...fileContentChunks];
+    // This returns an array with the starting byte pointers
+    // ex: For a 2300 byte file it would return: [0, 500, 1000, 1500, 2000]
+    const byteLocations = createByteLocations(fileSizeBytes);
+    const fileContentChunks = _.map(byteLocations, (byte, index) => {
+        return chunkGenerator({
+            idx: index + 1,
+            startingPoint: byte,
+            type: FILE.CHUNK_TYPES.FILE_CONTENTS
+        });
+    });
+
+    return [metaDataChunk, ...fileContentChunks];
 };
 
 const readBlob = blob =>
-  new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = function(evt) {
-      if (evt.target.readyState === FileReader.DONE) {
-        const arrayBuffer = evt.target.result;
-        resolve(arrayBuffer);
-      }
-    };
-    reader.readAsArrayBuffer(blob);
-  });
+    new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = function (evt) {
+            if (evt.target.readyState === FileReader.DONE) {
+                const arrayBuffer = evt.target.result;
+                resolve(arrayBuffer);
+            }
+        };
+        reader.readAsArrayBuffer(blob);
+    });
 
 const metaDataToChunkParams = (metaData, idx, handle, genesisHash) =>
-  chunkParamsGenerator({
-    idx: idx,
-    data: metaDataToIotaFormat(metaData, handle),
-    hash: genesisHash
-  });
+    chunkParamsGenerator({
+        idx: idx,
+        data: metaDataToIotaFormat(metaData, handle),
+        hash: genesisHash
+    });
 
 const fileContentsToChunkParams = (data, idx, genesisHash) =>
-  chunkParamsGenerator({
-    idx: idx,
-    data,
-    hash: genesisHash
-  });
+    chunkParamsGenerator({
+        idx: idx,
+        data,
+        hash: genesisHash
+    });
 
-const createChunkParams = (
-  chunk,
-  sliceCutOffFn,
-  fileContents,
-  metaData,
-  handle,
-  genesisHash
-) => {
-  const { idx, startingPoint, type } = chunk;
-  switch (type) {
-    case FILE.CHUNK_TYPES.FILE_CONTENTS:
-      const slice = fileContents.slice(
-        startingPoint,
-        sliceCutOffFn(startingPoint)
-      );
-      return fileContentsToChunkParams(slice, idx, genesisHash);
-    default:
-      return metaDataToChunkParams(metaData, idx, handle, genesisHash);
-  }
+const createChunkParams = (chunk,
+                           sliceCutOffFn,
+                           fileContents,
+                           metaData,
+                           handle,
+                           genesisHash) => {
+    const {idx, startingPoint, type} = chunk;
+    switch (type) {
+        case FILE.CHUNK_TYPES.FILE_CONTENTS:
+            const slice = fileContents.slice(
+                startingPoint,
+                sliceCutOffFn(startingPoint)
+            );
+            return fileContentsToChunkParams(slice, idx, genesisHash);
+        default:
+            return metaDataToChunkParams(metaData, idx, handle, genesisHash);
+    }
 };
 
 const createMetaData = (fileName, fileSizeBytes) => {
-  const fileExtension = fileName.split(".").pop();
-  const numberOfChunks = createByteLocations(fileSizeBytes).length;
+    const fileExtension = fileName.split(".").pop();
+    const numberOfChunks = createByteLocations(fileSizeBytes).length;
 
-  return {
-    fileName: fileName.substr(0, 500),
-    ext: fileExtension,
-    numberOfChunks
-  };
+    return {
+        fileName: fileName.substr(0, 500),
+        ext: fileExtension,
+        numberOfChunks
+    };
 };
 
 export default {
-  chunkParamsGenerator,
-  createByteChunks,
-  createChunkParams,
-  createMetaData,
-  decryptFile,
-  encryptFile,
-  initializeUpload,
-  metaDataFromIotaFormat,
-  metaDataToIotaFormat,
-  readBlob
+    chunkParamsGenerator,
+    createByteChunks,
+    createChunkParams,
+    createMetaData,
+    decryptFile,
+    encryptFile,
+    initializeUpload,
+    metaDataFromIotaFormat,
+    metaDataToIotaFormat,
+    readBlob
 };


### PR DESCRIPTION
-chunks can hold 0.8 kb instead of 0.6 kb.  
-added port to URLs
-removed prod brokernodes since they don't work with this version of webinterface anyway.  I have IPs of some Golang brokers if you need them.  

I ran this with no encryption at all and was able to do a 98 kb file in 91 chunks.  So there's definitely still an issue with the encryption, but taking out the base64 encoding and using a byte array instead helped.  I want to continue to look into encryption algorithms that don't increase the size of the data, but wanted to go ahead and push in what I've got so far.