### PR TITLE
Use lightweight transaction objects

### DIFF
--- a/src/services/iota.js
+++ b/src/services/iota.js
@@ -31,17 +31,49 @@ const parseMessage = message => {
   return Iota.utils.fromTrytes(evenChars);
 };
 
+const lightTxObjects = (trytes) => {
+  return _.map(trytes, (trytes) => {
+    if (!trytes) return
+
+    // validity check
+    for (var i = 2279; i < 2295; i++) {
+      if (trytes.charAt(i) !== "9") return
+    }
+
+    return {
+      signatureMessageFragment: trytes.slice(0, 2187),
+      address: trytes.slice(2187, 2268)
+    }
+  })
+}
+
+const queryTrytes = (iotaProvider, transactions) =>
+  new Promise((resolve, reject) => {
+    iotaProvider.api.getTrytes(transactions, (error, trytes) => {
+      if(error) {
+        return reject(error)
+      }
+
+      resolve(trytes)
+    })
+  });
+
 const queryTransactions = (iotaProvider, addresses) =>
   new Promise((resolve, reject) => {
-    iotaProvider.api.findTransactionObjects(
+    iotaProvider.api.findTransactions(
       { addresses },
-      (error, transactionObjects) => {
+      (error, transactions) => {
         if (error) {
           console.log("IOTA ERROR: ", error);
+          return reject(error)
         }
-        const settledTransactions = transactionObjects || [];
-        const uniqTransactions = _.uniqBy(settledTransactions, "address");
-        resolve(uniqTransactions);
+
+        queryTrytes(iotaProvider, transactions).then((trytes) => {
+          const transactionObjects = lightTxObjects(trytes)
+          const settledTransactions = transactionObjects || [];
+          const uniqTransactions = _.uniqBy(settledTransactions, "address");
+          resolve(uniqTransactions);
+        }, reject)
       }
     );
   });


### PR DESCRIPTION
As discussed in knowledge chat, the wrapper function in the iota API that was used so far involves a lot of unnecessary overhead.

The call was changed to two less abstracted calls, and parsing the transaction was cut down to the absolute minimum required to work, removing the need for a round of client side Curl, as well as making a trytes to trits conversion unnecessary for now.