### PR TITLE
Upload changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2647,9 +2647,7 @@
       }
     },
     "datamap-generator": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/datamap-generator/-/datamap-generator-1.0.3.tgz",
-      "integrity": "sha512-n9oG8ANkLYD16EVtJqmA3lJr+F5SwcurQKd38SFjUqQbQd+5QTTa7zE6yKtjzT4JJkrNpgXauKljYYwRQY8PSQ=="
+      "version": "git+https://github.com/oysterprotocol/datamap-generator.git#05cf3024b94bcaf3fe72301f1fcd6c17c376a1e9"
     },
     "date-now": {
       "version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-dom": "^16.2.0",
     "react-md-spinner": "^0.2.5",
     "react-redux": "^5.0.6",
+    "react-router": "^4.2.0",
     "react-router-redux": "next",
     "react-select": "^1.2.1",
     "redux": "^3.7.2",

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -15,7 +15,8 @@ export const IOTA_API = Object.freeze({
   PROVIDER_B: "http://18.220.1.63:14265",
   PROVIDER_C: "http://18.216.90.80:14265",
   ADDRESS_LENGTH: 81,
-  MESSAGE_LENGTH: 2187
+  MESSAGE_LENGTH: 2187,
+  BUNDLE_SIZE: 30
 });
 
 export const UPLOAD_STATUSES = Object.freeze({
@@ -32,7 +33,7 @@ export const DOWNLOAD_STATUSES = Object.freeze({
 });
 
 export const FILE = Object.freeze({
-  MAX_FILE_SIZE: 200 * 1000,
+  MAX_FILE_SIZE: 2000 * 1000,
   CHUNK_TYPES: {
     METADATA: "METADATA",
     FILE_CONTENTS: "FILE_CONTENTS"

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -38,3 +38,5 @@ export const FILE = Object.freeze({
     FILE_CONTENTS: "FILE_CONTENTS"
   }
 });
+
+export const INCLUDE_TREASURE_OFFSETS = false;

--- a/src/redux/epics/upload-epic.js
+++ b/src/redux/epics/upload-epic.js
@@ -7,7 +7,7 @@ import uploadActions from "redux/actions/upload-actions";
 import { UPLOAD_STATUSES } from "config";
 import Iota from "services/iota";
 import Backend from "services/backend";
-import { generate as genDatamap } from "datamap-generator";
+import Datamap from "datamap-generator";
 import FileProcessor from "utils/file-processor";
 
 const initializeUpload = (action$, store) => {
@@ -52,7 +52,9 @@ const refreshIncompleteUploads = (action$, store) => {
   return action$
     .ofType(uploadActions.REFRESH_INCOMPLETE_UPLOADS)
     .flatMap(action => {
-      const { upload: { history } } = store.getState();
+      const {
+        upload: { history }
+      } = store.getState();
       const incompleteUploads = history.filter(
         f => f.status === UPLOAD_STATUSES.SENT && f.uploadProgress < 100
       );
@@ -65,7 +67,7 @@ const refreshIncompleteUploads = (action$, store) => {
 const pollUploadProgress = (action$, store) => {
   return action$.ofType(uploadActions.BEGIN_UPLOAD).switchMap(action => {
     const { numberOfChunks, handle } = action.payload;
-    const datamap = genDatamap(handle, numberOfChunks);
+    const datamap = Datamap.generate(handle, numberOfChunks);
     const addresses = _.values(datamap);
     // console.log("POLLING 81 CHARACTER IOTA ADDRESSES: ", addresses);
 

--- a/src/redux/epics/upload-epic.js
+++ b/src/redux/epics/upload-epic.js
@@ -71,6 +71,8 @@ const pollUploadProgress = (action$, store) => {
     const addresses = _.values(datamap);
     // console.log("POLLING 81 CHARACTER IOTA ADDRESSES: ", addresses);
 
+    Iota.initializePolling(addresses);
+
     return Observable.interval(5000)
       .takeUntil(
         Observable.merge(
@@ -83,9 +85,12 @@ const pollUploadProgress = (action$, store) => {
       )
       .mergeMap(action =>
         Observable.fromPromise(Iota.checkUploadPercentage(addresses))
-          .map(uploadProgress =>
-            uploadActions.updateUploadProgress({ handle, uploadProgress })
-          )
+          .map(uploadProgress => {
+            return uploadActions.updateUploadProgress({
+              handle,
+              uploadProgress
+            });
+          })
           .catch(error => Observable.empty())
       );
   });

--- a/src/services/backend.js
+++ b/src/services/backend.js
@@ -18,7 +18,12 @@ const uploadFile = (data, fileName, handle) => {
   const byteChunks = FileProcessor.createByteChunks(fileSize);
   const storageLengthInYears = 999; /*@TODO make this a real thing*/
 
-  return createUploadSession(API.BROKER_NODE_A, fileSize, genesisHash, storageLengthInYears)
+  return createUploadSession(
+    API.BROKER_NODE_A,
+    fileSize,
+    genesisHash,
+    storageLengthInYears
+  )
     .then(({ alphaSessionId, betaSessionId }) =>
       Promise.all([
         sendToAlphaBroker(
@@ -48,7 +53,12 @@ const uploadFile = (data, fileName, handle) => {
     });
 };
 
-const createUploadSession = (host, fileSizeBytes, genesisHash, storageLengthInYears) =>
+const createUploadSession = (
+  host,
+  fileSizeBytes,
+  genesisHash,
+  storageLengthInYears
+) =>
   new Promise((resolve, reject) => {
     axiosInstance
       .post(`${host}${API.V2_UPLOAD_SESSIONS_PATH}`, {
@@ -61,7 +71,7 @@ const createUploadSession = (host, fileSizeBytes, genesisHash, storageLengthInYe
         console.log("UPLOAD SESSION SUCCESS: ", data);
         const { id: alphaSessionId, betaSessionId } = data;
         const { invoice: invoice } = data;
-        resolve({ alphaSessionId, betaSessionId, invoice});
+        resolve({ alphaSessionId, betaSessionId, invoice });
       })
       .catch(error => {
         console.log("UPLOAD SESSION ERROR: ", error);
@@ -92,7 +102,8 @@ const sendFileToBroker = (
   byteChunks,
   sliceCutOffFn
 ) => {
-  const batches = _.chunk(byteChunks, API.CHUNKS_PER_REQUEST);
+  const batches = [_.slice(byteChunks, 0, byteChunks.length)];
+
   const batchRequests = batches.map(
     batch =>
       new Promise((resolve, reject) => {

--- a/src/services/iota.js
+++ b/src/services/iota.js
@@ -72,19 +72,17 @@ const skinnyQueryTransactions = (iotaProvider, addresses) =>
     );
   });
 
-const initializePolling = addresses =>
-  new Promise((resolve, reject) => {
-    totalLength = addresses.length;
+const initializePolling = addresses => {
+  totalLength = addresses.length;
 
-    indexes.startingIdx = 0;
-    indexes.endingIdx = addresses.length - 1;
-    indexes.latestFoundBackIdx = indexes.endingIdx;
+  indexes.startingIdx = 0;
+  indexes.endingIdx = addresses.length - 1;
+  indexes.latestFoundBackIdx = indexes.endingIdx;
 
-    indexes.frontIdx =
-      indexes.startingIdx + Math.floor(Math.random() * BUNDLE_SIZE);
-    indexes.backIdx =
-      indexes.endingIdx - Math.floor(Math.random() * BUNDLE_SIZE);
-  });
+  indexes.frontIdx =
+    indexes.startingIdx + Math.floor(Math.random() * BUNDLE_SIZE);
+  indexes.backIdx = indexes.endingIdx - Math.floor(Math.random() * BUNDLE_SIZE);
+};
 
 const checkUploadPercentage = addresses => {
   let backOfFile = new Promise((resolve, reject) => {

--- a/src/services/iota.js
+++ b/src/services/iota.js
@@ -16,6 +16,19 @@ const IotaC = new IOTA({
   provider: IOTA_API.PROVIDER_C
 });
 
+const BUNDLE_SIZE = IOTA_API.BUNDLE_SIZE;
+
+let totalLength = 0;
+
+let indexes = {
+  startingIdx: 0,
+  endingIdx: 0,
+  frontIdx: 0,
+  backIdx: 0,
+  latestFoundFrontIdx: 0,
+  latestFoundBackIdx: 0
+};
+
 const toAddress = string => string.substr(0, IOTA_API.ADDRESS_LENGTH);
 
 const parseMessage = message => {
@@ -46,13 +59,82 @@ const queryTransactions = (iotaProvider, addresses) =>
     );
   });
 
-const checkUploadPercentage = addresses =>
+const skinnyQueryTransactions = (iotaProvider, addresses) =>
   new Promise((resolve, reject) => {
-    queryTransactions(IotaA, addresses).then(transactions => {
-      const percentage = transactions.length / addresses.length * 100;
-      resolve(percentage);
-    });
+    iotaProvider.api.findTransactions(
+      { addresses },
+      (error, transactionHashes) => {
+        if (error) {
+          console.log("IOTA ERROR: ", error);
+        }
+        resolve(transactionHashes);
+      }
+    );
   });
+
+const initializePolling = addresses =>
+  new Promise((resolve, reject) => {
+    totalLength = addresses.length;
+
+    indexes.startingIdx = 0;
+    indexes.endingIdx = addresses.length - 1;
+    indexes.latestFoundBackIdx = indexes.endingIdx;
+
+    indexes.frontIdx =
+      indexes.startingIdx + Math.floor(Math.random() * BUNDLE_SIZE);
+    indexes.backIdx =
+      indexes.endingIdx - Math.floor(Math.random() * BUNDLE_SIZE);
+  });
+
+const checkUploadPercentage = addresses => {
+  let backOfFile = new Promise((resolve, reject) => {
+    skinnyQueryTransactions(IotaA, [addresses[indexes.backIdx]]).then(
+      transactions => {
+        if (transactions.length > 0) {
+          indexes.latestFoundBackIdx = indexes.backIdx;
+          updateBackIndex(indexes.backIdx);
+        }
+        resolve();
+      }
+    );
+  });
+
+  let frontOfFile = new Promise((resolve, reject) => {
+    skinnyQueryTransactions(IotaA, [addresses[indexes.frontIdx]]).then(
+      transactions => {
+        if (transactions.length > 0) {
+          indexes.latestFoundFrontIdx = indexes.frontIdx;
+          updateFrontIndex(indexes.frontIdx);
+        }
+        resolve();
+      }
+    );
+  });
+
+  return Promise.all([frontOfFile, backOfFile]).then(() => {
+    return recalculatePercentage(indexes);
+  });
+};
+
+const recalculatePercentage = indexes => {
+  if (indexes.latestFoundFrontIdx >= indexes.latestFoundBackIdx - 1) {
+    return 100;
+  }
+  return (
+    (indexes.latestFoundFrontIdx +
+      (indexes.endingIdx - indexes.latestFoundBackIdx)) /
+    (totalLength - 2) *
+    100
+  );
+};
+
+const updateFrontIndex = frontIndex => {
+  indexes.frontIdx = frontIndex + Math.floor(Math.random() * BUNDLE_SIZE);
+};
+
+const updateBackIndex = backIndex => {
+  indexes.backIdx = backIndex - Math.floor(Math.random() * BUNDLE_SIZE);
+};
 
 const findTransactions = addresses =>
   new Promise((resolve, reject) => {
@@ -70,6 +152,7 @@ const findTransactions = addresses =>
   });
 
 export default {
+  initializePolling,
   toAddress,
   parseMessage,
   checkUploadPercentage,

--- a/src/utils/encryption.js
+++ b/src/utils/encryption.js
@@ -36,8 +36,9 @@ const genesisHash = handle => {
   return genHash;
 };
 
-const byteArrayToWordArray = (ba) => {
-  let wa = [], i;
+const byteArrayToWordArray = ba => {
+  let wa = [],
+    i;
   for (i = 0; i < ba.length; i++) {
     wa[(i / 4) | 0] |= ba[i] << (24 - 8 * i);
   }
@@ -46,7 +47,10 @@ const byteArrayToWordArray = (ba) => {
 };
 
 const wordArrayToByteArray = (wordArray, length) => {
-  if (wordArray.hasOwnProperty("sigBytes") && wordArray.hasOwnProperty("words")) {
+  if (
+    wordArray.hasOwnProperty("sigBytes") &&
+    wordArray.hasOwnProperty("words")
+  ) {
     length = wordArray.sigBytes;
     wordArray = wordArray.words;
   }
@@ -65,15 +69,11 @@ const wordArrayToByteArray = (wordArray, length) => {
 
 const wordToByteArray = (word, length) => {
   let ba = [],
-    xFF = 0xFF;
-  if (length > 0)
-    ba.push(word >>> 24);
-  if (length > 1)
-    ba.push((word >>> 16) & xFF);
-  if (length > 2)
-    ba.push((word >>> 8) & xFF);
-  if (length > 3)
-    ba.push(word & xFF);
+    xFF = 0xff;
+  if (length > 0) ba.push(word >>> 24);
+  if (length > 1) ba.push((word >>> 16) & xFF);
+  if (length > 2) ba.push((word >>> 8) & xFF);
+  if (length > 3) ba.push(word & xFF);
 
   return ba;
 };
@@ -91,7 +91,10 @@ function bin2String(array) {
 }
 
 const encrypt = (byteArray, secretKey) =>
-  CryptoJS.Rabbit.encrypt(byteArrayToWordArray(byteArray), secretKey).toString();
+  CryptoJS.Rabbit.encrypt(
+    byteArrayToWordArray(byteArray),
+    secretKey
+  ).toString();
 
 const decrypt = (text, secretKey) =>
   wordArrayToByteArray(CryptoJS.Rabbit.decrypt(text, secretKey));
@@ -102,7 +105,6 @@ const encryptMetaData = (text, secretKey) =>
 const decryptMetaData = (text, secretKey) =>
   CryptoJS.AES.decrypt(text, secretKey).toString(CryptoJS.enc.Utf8);
 
-
 export default {
   parseEightCharsOfFilename,
   getSalt,
@@ -112,5 +114,5 @@ export default {
   encrypt,
   decrypt,
   decryptMetaData,
-  encryptMetaData,
+  encryptMetaData
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1923,9 +1923,9 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-"datamap-generator@git+https://github.com/oysterprotocol/datamap-generator.git":
+"datamap-generator@https://github.com/oysterprotocol/datamap-generator.git":
   version "1.0.3"
-  resolved "git+https://github.com/oysterprotocol/datamap-generator.git#1b8865190fee6bc5dc3947f14013db0f656e0e7e"
+  resolved "https://github.com/oysterprotocol/datamap-generator.git#1b8865190fee6bc5dc3947f14013db0f656e0e7e"
 
 date-now@^0.1.4:
   version "0.1.4"


### PR DESCRIPTION
-send all chunks to brokers at once.  Will change this to only send 60% to each in a future PR
-instead of polling on all the addresses and calling "findTransactionObjects" we will be polling on only one address at a time, and only calling "findTransactions".  We also won't poll on every address but on roughly 1 out of every X addresses.  This is because the broker bundles transactions and if one transaction in the bundle got attached, they all did.  