### PR TITLE
Better address index selection

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -41,3 +41,4 @@ export const INCLUDE_TREASURE_OFFSETS = false;
 export const NUM_BROKER_CHANNELS = 3; // number of broker cores - 1
 export const SECONDS_PER_CHUNK = 0.035; // if MWM is changed this will be incorrect
 export const MAX_ADDRESSES = 1000;
+export const NUM_POLLING_ADDRESSES = 101;

--- a/src/redux/actions/upload-actions.js
+++ b/src/redux/actions/upload-actions.js
@@ -53,14 +53,9 @@ const ACTIONS = Object.freeze({
     type: ACTIONS.UPLOAD_FAILURE,
     payload: handle
   }),
-  updateUploadProgress: ({
-    handle,
-    uploadProgress,
-    frontIndex,
-    backIndex
-  }) => ({
+  updateUploadProgress: ({ handle, uploadProgress, indexes }) => ({
     type: ACTIONS.UPDATE_UPLOAD_PROGRESS,
-    payload: { handle, uploadProgress, frontIndex, backIndex }
+    payload: { handle, uploadProgress, indexes }
   }),
   markUploadAsComplete: handle => ({
     type: ACTIONS.MARK_UPLOAD_AS_COMPLETE,
@@ -81,9 +76,9 @@ const ACTIONS = Object.freeze({
     type: ACTIONS.SELECT_BETA_BROKER,
     payload: url
   }),
-  initializePollingIndexes: ({ frontIdx, backIdx, dataMapLength }) => ({
+  initializePollingIndexes: ({ indexes, dataMapLength }) => ({
     type: ACTIONS.INITIALIZE_POLLING_INDEXES,
-    payload: { frontIdx, backIdx, dataMapLength }
+    payload: { indexes, dataMapLength }
   })
 });
 

--- a/src/redux/reducers/upload-reducer.js
+++ b/src/redux/reducers/upload-reducer.js
@@ -5,10 +5,8 @@ const initState = {
   alphaBroker: API.BROKER_NODE_A,
   betaBroker: API.BROKER_NODE_B,
   indexes: {
-    startingIdx: 0,
-    endingIdx: 0,
-    frontIdx: 0,
-    backIdx: 0
+    indexes: [],
+    startingLength: 0
   },
   dataMapLength: 0,
   history: [
@@ -44,21 +42,19 @@ const uploadReducer = (state = initState, action) => {
       const {
         handle: fileHandle,
         uploadProgress,
-        frontIndex,
-        backIndex
+        indexes: updatedIndexes
       } = action.payload;
       const updatedHistory = state.history.map(f => {
         return f.handle === fileHandle ? { ...f, uploadProgress } : f;
       });
-      const newIndexes = {
+      const updated = {
         ...state.indexes,
-        frontIdx: frontIndex,
-        backIdx: backIndex
+        indexes: updatedIndexes
       };
       return {
         ...state,
         history: updatedHistory,
-        indexes: newIndexes
+        indexes: updated
       };
 
     case uploadActions.ADD_TO_HISTORY:
@@ -96,16 +92,15 @@ const uploadReducer = (state = initState, action) => {
       };
 
     case uploadActions.INITIALIZE_POLLING_INDEXES:
-      const { frontIdx, backIdx, dataMapLength } = action.payload;
-      const indexes = {
+      const { indexes, dataMapLength } = action.payload;
+      const initial = {
         ...state.indexes,
-        endingIdx: dataMapLength - 1,
-        frontIdx,
-        backIdx
+        indexes,
+        startingLength: indexes.length
       };
       return {
         ...state,
-        indexes,
+        indexes: initial,
         dataMapLength
       };
 

--- a/src/utils/index-selector.js
+++ b/src/utils/index-selector.js
@@ -1,0 +1,47 @@
+const selectPollingIndexes = (addresses, numPollingAddresses, bundleSize) => {
+  // What this if is checking for is basically medium-sized uploads
+  // which would have been better off with the old random index selection.
+  // For those uploads, pick indexes the old way.
+  if (
+    addresses.length <
+    (bundleSize + bundleSize / 2) / 2 * numPollingAddresses
+  ) {
+    let indexArray = [0];
+    while (addresses.length - 1 > indexArray[indexArray.length - 1]) {
+      indexArray = indexArray.concat(
+        Math.min(
+          ...[
+            indexArray[indexArray.length - 1] +
+              Math.floor(Math.random() * (bundleSize / 2)) +
+              bundleSize / 2,
+            addresses.length - 1
+          ]
+        )
+      );
+    }
+    if (indexArray.length === 2) {
+      //make sure there's always at least 3 addresses
+      indexArray.splice(1, 0, Math.floor(addresses.length / 2));
+    }
+    return indexArray;
+  } else {
+    return selectPollingIndexesLarge(addresses, numPollingAddresses);
+  }
+};
+
+const selectPollingIndexesLarge = (addresses, numPollingAddresses) => {
+  const offset = addresses.length / (numPollingAddresses - 1);
+
+  let indexes = [];
+  for (let i = 0; i <= numPollingAddresses - 2; i++) {
+    indexes.push(Math.floor(i * offset));
+  }
+  indexes.push(addresses.length - 1);
+
+  return indexes;
+};
+
+export default {
+  selectPollingIndexesLarge,
+  selectPollingIndexes
+};

--- a/src/utils/index-selector.test.js
+++ b/src/utils/index-selector.test.js
@@ -1,0 +1,81 @@
+import _ from "lodash";
+
+import IndexSelector from "./index-selector";
+import { NUM_POLLING_ADDRESSES } from "../config";
+import { IOTA_API } from "../config";
+
+const BUNDLE_SIZE = IOTA_API.BUNDLE_SIZE;
+
+const generateAddresses = length => {
+  const someAddress =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ9ABCDEFGHIJKLMNOPQRSTUVWXYZ9ABCDEFGHIJKLMNOPQRSTUVWXYZ9";
+  return Array(length).fill(someAddress);
+};
+
+test(
+  "selectPollingIndexes, for small files it should not necessarily insist on NUM_POLLING_ADDRESSES " +
+    "indexes",
+  done => {
+    let addresses = generateAddresses(101);
+    let indexes = IndexSelector.selectPollingIndexes(
+      addresses,
+      NUM_POLLING_ADDRESSES,
+      BUNDLE_SIZE
+    );
+    let uniqueIndexes = _.uniq(indexes);
+
+    // there should be exactly NUM_POLLING_ADDRESSES
+    expect(indexes.length).not.toEqual(NUM_POLLING_ADDRESSES);
+    // first and last should be equal to 0 and addresses.length - 1
+    expect(indexes[0]).toEqual(0);
+    expect(indexes[indexes.length - 1]).toEqual(100);
+    // they should all be unique
+    expect(indexes).toEqual(uniqueIndexes);
+
+    done();
+  }
+);
+
+test(
+  "selectPollingIndexesLarge, huge file -- for datamap length > NUM_POLLING_ADDRESSES, " +
+    "it should return 100 unique indexes",
+  done => {
+    let addresses = generateAddresses(5845888);
+    let indexes = IndexSelector.selectPollingIndexesLarge(
+      addresses,
+      NUM_POLLING_ADDRESSES
+    );
+    let uniqueIndexes = _.uniq(indexes);
+
+    // there should be exactly NUM_POLLING_ADDRESSES
+    expect(indexes.length).toEqual(NUM_POLLING_ADDRESSES);
+    // first and last should be equal to 0 and addresses.length - 1
+    expect(indexes[0]).toEqual(0);
+    expect(indexes[NUM_POLLING_ADDRESSES - 1]).toEqual(5845887);
+    // they should all be unique
+    expect(indexes).toEqual(uniqueIndexes);
+
+    done();
+  }
+);
+
+test("selectPollingIndexesLarge, should still work with a number that is not NUM_POLLING_ADDRESSES", done => {
+  let numPollingForThisTest = 10;
+
+  let addresses = generateAddresses(8000);
+  let indexes = IndexSelector.selectPollingIndexesLarge(
+    addresses,
+    numPollingForThisTest
+  );
+  let uniqueIndexes = _.uniq(indexes);
+
+  // there should be exactly numPollingForThisTest
+  expect(indexes.length).toEqual(numPollingForThisTest);
+  // first and last should be equal to 0 and addresses.length - 1
+  expect(indexes[0]).toEqual(0);
+  expect(indexes[numPollingForThisTest - 1]).toEqual(7999);
+  // they should all be unique
+  expect(indexes).toEqual(uniqueIndexes);
+
+  done();
+});


### PR DESCRIPTION
Implements the polling changes discussed in the doc from yesterday, with one change.  I realized that for smallish files, the polling would actually be slower with this new method, so the indexes are selected differently based on file size.  Smaller files use the old method of picking indexes.  

For either index selection method, instead of picking indexes after each new index is found, we pick them all before we start polling.