### PR TITLE
Adds versioning to meta chunk

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,9 +57,9 @@
     "start": "cross-env NODE_PATH=src react-scripts start",
     "build": "cross-env NODE_PATH=src react-scripts build",
     "test": "jest",
-    "watch-test": "cross-env NODE_PATH=src jest --watch --colors",
-    "eject": "cross-env NODE_PATH=src react-scripts eject",
-    "cypress:open": "cypress open"
+    "test:watch": "cross-env NODE_PATH=src jest --watch --colors",
+    "cypress:open": "cypress open",
+    "eject": "cross-env NODE_PATH=src react-scripts eject"
   },
   "jest": {
     "roots": [

--- a/src/utils/file-processor.js
+++ b/src/utils/file-processor.js
@@ -113,7 +113,6 @@ const fileToChunks = (file, handle, opts = {}) =>
           const versionedMeta = addVersionToMeta(encryptedMeta);
           const trytedMetaData = Iota.addStopperTryte(
             Iota.utils.toTrytes(versionedMeta)
-            // Iota.utils.toTrytes(encryptedMeta)
           );
 
           encryptedChunks = [


### PR DESCRIPTION
NOTE: I store the version as a string in hex because JS does not natively support integers (wat?!), which made it unnecessarily difficult and error prone. 

If we are really concerned about space, I don't think we need 4 bytes, 2 bytes is more than enough. I doubt we will ever reach v65536