### PR TITLE
use uint32 for version

### DIFF
--- a/src/utils/file-processor.js
+++ b/src/utils/file-processor.js
@@ -71,16 +71,13 @@ const addVersionToMeta = metaStr => {
   const typedVersion = new DataView(new ArrayBuffer(VERSION_BYTES));
   typedVersion.setUint32(0, CURRENT_VERSION);
   const buf = new forge.util.ByteBuffer(typedVersion.buffer);
-  const trytes = Iota.utils.toTrytes(buf.bytes());
-  return `${trytes}${metaStr}`;
+  return `${buf.bytes()}${metaStr}`;
 };
 
 const parseMetaVersion = metaRaw => {
-  const idx = 2 * VERSION_BYTES; // 2 chars per byte in hex
-  const trytes = metaRaw.substring(0, idx);
-  const meta = metaRaw.substring(idx);
-  const buf = new forge.util.ByteBuffer(Iota.utils.fromTrytes(trytes));
-  const bytes = forge.util.binary.raw.decode(buf.bytes());
+  const rawVersion = metaRaw.substring(0, VERSION_BYTES);
+  const meta = metaRaw.substring(VERSION_BYTES);
+  const bytes = forge.util.binary.raw.decode(rawVersion);
   const version = (new DataView(bytes.buffer)).getUint32(0);
 
   return { version, meta };

--- a/src/utils/file-processor.js
+++ b/src/utils/file-processor.js
@@ -1,5 +1,6 @@
 import Encryption from "utils/encryption";
 import _ from "lodash";
+import forge from "node-forge";
 
 import Iota from "../services/iota";
 
@@ -8,7 +9,7 @@ const fileSizeFromNumChunks = numChunks => numChunks * CHUNK_SIZE;
 
 // DO NOT CHANGE THIS! It will  break encoding/decoding  meta chunks.
 const VERSION_BYTES = 4;
-const CURRENT_VERSION = "00000001"; // 4 bytes in hex (8 chars)
+const CURRENT_VERSION = 1;
 
 const initializeUpload = file => {
   const handle = createHandle(file.name);
@@ -66,14 +67,21 @@ const createMetaData = (fileName, numberOfChunks) => {
   return JSON.stringify(meta);
 };
 
-const addVersionToMeta = metaStr => `${CURRENT_VERSION}${metaStr}`;
+const addVersionToMeta = metaStr => {
+  const typedVersion = new DataView(new ArrayBuffer(VERSION_BYTES));
+  typedVersion.setUint32(0, CURRENT_VERSION);
+  const buf = new forge.util.ByteBuffer(typedVersion.buffer);
+  const trytes = Iota.utils.toTrytes(buf.bytes());
+  return `${trytes}${metaStr}`;
+};
 
 const parseMetaVersion = metaRaw => {
   const idx = 2 * VERSION_BYTES; // 2 chars per byte in hex
-  const vStr = metaRaw.substring(0, idx);
+  const trytes = metaRaw.substring(0, idx);
   const meta = metaRaw.substring(idx);
-
-  const version = parseInt(`0x${vStr}`);
+  const buf = new forge.util.ByteBuffer(Iota.utils.fromTrytes(trytes));
+  const bytes = forge.util.binary.raw.decode(buf.bytes());
+  const version = (new DataView(bytes.buffer)).getUint32(0);
 
   return { version, meta };
 };


### PR DESCRIPTION
This version uses Javascript DataViews to express the protocol version in the metachunk. I was going to use Uint32Arrays first, but turns out their endianness depends on the platform. 

node-forge also provides a way to do this, but the comment in the source says `uint32`, while the function name and result are `int32`. Due to that ambiguity I decided against it for now. In the future if downward compatibility is required we could have another look at `ByteStringBuffer.putInt32` and `ByteStringBuffer.getInt32` respectively. The latter would require a `>>> 0` of the result to get it unsigned.