### PR TITLE
feature/authenticated chunks

### DIFF
--- a/src/utils/encryption.js
+++ b/src/utils/encryption.js
@@ -104,6 +104,11 @@ const encryptChunk = (key, idx, secret) => {
 const decryptChunk = (key, secret) => {
   key.read = 0;
 
+  // Require a payload of at least one byte to attempt decryption
+  if (secret.length <= (IV_LENGTH + TAG_LENGTH)) {
+    return "";
+  }
+
   const iv = secret.substr(-IV_LENGTH);
   const tag = secret.substr(-TAG_LENGTH - IV_LENGTH, TAG_LENGTH);
   const decipher = forge.cipher.createDecipher("AES-GCM", key);

--- a/src/utils/encryption.js
+++ b/src/utils/encryption.js
@@ -91,7 +91,8 @@ const encryptChunk = (key, idx, secret) => {
 
   cipher.start({
     iv: iv,
-    tagLength: TAG_LENGTH * 8
+    tagLength: TAG_LENGTH * 8,
+    additionalData: 'binary-encoded string'
   });
 
   cipher.update(forge.util.createBuffer(secret));
@@ -102,6 +103,7 @@ const encryptChunk = (key, idx, secret) => {
 
 const decryptChunk = (key, secret) => {
   key.read = 0;
+
   const iv = secret.substr(-IV_LENGTH);
   const tag = secret.substr(-TAG_LENGTH - IV_LENGTH, TAG_LENGTH);
   const decipher = forge.cipher.createDecipher("AES-GCM", key);
@@ -109,7 +111,8 @@ const decryptChunk = (key, secret) => {
   decipher.start({
     iv: iv,
     tag: tag,
-    tagLength: TAG_LENGTH * 8
+    tagLength: TAG_LENGTH * 8,
+    additionalData: 'binary-encoded string'
   });
 
   decipher.update(

--- a/src/utils/encryption.js
+++ b/src/utils/encryption.js
@@ -129,7 +129,7 @@ const decryptChunk = (key, secret) => {
     return "";
   }
 
-  return decipher.output
+  return decipher.output.bytes()
 };
 
 export default {

--- a/src/utils/encryption.js
+++ b/src/utils/encryption.js
@@ -4,6 +4,7 @@ import Raven from "raven-js";
 import analytics from "analytics.js";
 
 const IV_LENGTH = 16;
+const TAG_LENGTH = 16;
 const CHUNK_PREFIX = "File_chunk_data: ";
 const CHUNK_PREFIX_IN_HEX = forge.util.bytesToHex(CHUNK_PREFIX);
 
@@ -27,6 +28,16 @@ export function getSalt(length) {
   const byteArr = forge.util.binary.raw.decode(bytes);
   const salt = forge.util.binary.base58.encode(byteArr);
   return salt.substr(0, length);
+}
+
+export function getNonce (key, idx) {
+  const nonce = forge.util.binary.hex.decode(idx.toString(16));
+  return forge.md.sha384
+          .create()
+          .update(key.bytes())
+          .update(nonce)
+          .digest()
+          .getBytes(IV_LENGTH);
 }
 
 export function getPrimordialHash() {
@@ -73,53 +84,44 @@ const obfuscatedGenesisHash = hash => {
   return forge.util.bytesToHex(obfuscatedHash);
 };
 
-const encryptChunk = (key, secret) => {
+const encryptChunk = (key, idx, secret) => {
   key.read = 0;
-  const iv = forge.random.getBytesSync(16);
+  const iv = getNonce(key, idx);
   const cipher = forge.cipher.createCipher("AES-GCM", key);
 
   cipher.start({
     iv: iv,
-    tagLength: 0
+    tagLength: TAG_LENGTH * 8
   });
 
-  cipher.update(forge.util.createBuffer(CHUNK_PREFIX + secret));
+  cipher.update(forge.util.createBuffer(secret));
   cipher.finish();
 
-  return cipher.output.getBytes() + iv;
+  return cipher.output.bytes() + cipher.mode.tag.bytes() + iv;
 };
 
 const decryptChunk = (key, secret) => {
   key.read = 0;
   const iv = secret.substr(-IV_LENGTH);
+  const tag = secret.substr(-TAG_LENGTH - IV_LENGTH, TAG_LENGTH);
   const decipher = forge.cipher.createDecipher("AES-GCM", key);
 
   decipher.start({
     iv: iv,
-    tagLength: 0,
-    output: null
+    tag: tag,
+    tagLength: TAG_LENGTH * 8
   });
 
   decipher.update(
-    forge.util.createBuffer(secret.substring(0, secret.length - IV_LENGTH))
+    forge.util.createBuffer(secret.substring(0, secret.length - TAG_LENGTH - IV_LENGTH))
   );
 
+  // Most likely a treasure chunk, skip
   if (!decipher.finish()) {
-    let msg =
-      "decipher failed to finished in decryptChunk in utils/encryption.js";
-    Raven.captureException(new Error(msg));
     return "";
   }
 
-  const hexedOutput = forge.util.bytesToHex(decipher.output);
-
-  if (_.startsWith(hexedOutput, CHUNK_PREFIX_IN_HEX)) {
-    return forge.util.hexToBytes(
-      hexedOutput.substr(CHUNK_PREFIX_IN_HEX.length, hexedOutput.length)
-    );
-  } else {
-    return "";
-  }
+  return decipher.output
 };
 
 export default {

--- a/src/utils/encryption.test.js
+++ b/src/utils/encryption.test.js
@@ -11,7 +11,7 @@ const metaData =
   '{"fileName":"ditto - Copy.png","ext":"png","numberOfChunks":3}';
 
 test("chunk > encrypt > decrypt > chunk", done => {
-  const encryptionResult = Encryption.encryptChunk(handleInBytes, secret);
+  const encryptionResult = Encryption.encryptChunk(handleInBytes, 1, secret);
 
   const trytedResultWithStopperAndPadding =
     Iota.utils.toTrytes(encryptionResult) + "A" + "9999999999";
@@ -30,7 +30,7 @@ test("chunk > encrypt > decrypt > chunk", done => {
 });
 
 test("metadata > encrypt > decrypt > metadata", done => {
-  const encryptionResult = Encryption.encryptChunk(handleInBytes, metaData);
+  const encryptionResult = Encryption.encryptChunk(handleInBytes, 0, metaData);
 
   const trytedResultWithStopperAndPadding =
     Iota.utils.toTrytes(encryptionResult) + "A" + "9999999999";

--- a/src/utils/file-processor.js
+++ b/src/utils/file-processor.js
@@ -21,14 +21,11 @@ const initializeUpload = file => {
 
 const metaDataFromIotaFormat = (trytes, handle) => {
   const handleInBytes = Encryption.bytesFromHandle(handle);
-
   const stopperRemoved = Iota.removeStopperTryteAndPadding(trytes);
   const encryptedData = Iota.utils.fromTrytes(
     Iota.addPaddingIfOdd(stopperRemoved)
   );
-
   const { version, meta: encryptedMeta } = parseMetaVersion(encryptedData);
-
   const decryptedData = Encryption.decryptChunk(handleInBytes, encryptedMeta);
 
   return JSON.parse(decryptedData);
@@ -96,8 +93,8 @@ const fileToChunks = (file, handle, opts = {}) =>
       Promise.all(chunks.map(readBlob)).then(arrayBuffer => {
         let encryptedChunks = arrayBuffer
           .map(arrayBufferToString)
-          .map(binaryString =>
-            Encryption.encryptChunk(handleInBytes, binaryString)
+          .map((binaryString, idx) =>
+            Encryption.encryptChunk(handleInBytes, idx + 1, binaryString)
           )
           .map(Iota.utils.toTrytes)
           .map(Iota.addStopperTryte)
@@ -107,6 +104,7 @@ const fileToChunks = (file, handle, opts = {}) =>
           const metaChunk = createMetaData(file.name, chunksCount);
           const encryptedMeta = Encryption.encryptChunk(
             handleInBytes,
+            0,
             metaChunk
           );
 


### PR DESCRIPTION
This PR updates the encryption to rely on GCM auth to encrypt/decrypt chunks.

This makes it easy to just skip any chunks that fail the auth, thus leaving only those belonging to the file. 

For an extra integrity check the final number of chunks could be compared to the number expected, to verify that a file is complete. That's not part of the PR.