### PR TITLE
Poll on more addresses

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -67,4 +67,4 @@ export const INCLUDE_TREASURE_OFFSETS = true;
 export const NUM_BROKER_CHANNELS = 3; // number of broker cores - 1
 export const SECONDS_PER_CHUNK = 0.035; // if MWM is changed this will be incorrect
 export const MAX_ADDRESSES = 1000;
-export const NUM_POLLING_ADDRESSES = 101;
+export const NUM_POLLING_ADDRESSES = 301;


### PR DESCRIPTION
With huge files, sometimes webinterface thinks the upload is done when it's not.  Increase the number of addresses we poll on for now, and revisit after mainnet.  