### PR TITLE
min progress

### DIFF
--- a/src/components/upload-started/upload-started-slide.js
+++ b/src/components/upload-started/upload-started-slide.js
@@ -24,8 +24,8 @@ const UploadStartedSlide = ({ uploadProgress }) => (
         className="upload-progress-bar"
       />
       <p>
-        {Math.floor(Math.min(100, uploadProgress))}% - File is being broken into
-        chunks and each chunk encrypted…
+        {Math.floor(Math.min(100, Math.min(7, uploadProgress)))}% - File is
+        being broken into chunks and each chunk encrypted…
       </p>
     </div>
   </Slide>


### PR DESCRIPTION
Have a min % to users don't feel antsy when they see it stuck at 0%. Safari and chrome both do this when showing a progress bar.