### PR TITLE
Fix mobile overflow UI bug

### DIFF
--- a/src/components/responsive.css
+++ b/src/components/responsive.css
@@ -131,6 +131,48 @@
   .logo_img {
     width: 46%;
   }
+
+  /* mobile fix: centers, declutters, and wraps the UI */
+  .choice-wrapper {
+    flex-wrap: wrap;
+  }
+  .choice-section {
+    padding: 50px 5px 0 5px;
+  }
+  .choice-wrapper .tangle-image {
+    display: none;
+  }
+
+  .slide .container {
+    flex-direction: column;
+  }
+  .slide-image-wrapper {
+    order: -1;
+  }
+  .slide-custom-image {
+    padding-top: 25px;
+    position: relative;
+  }
+  .slide-tangle-image {
+    display: none;
+  }
+  .slide-body {
+    padding-top: 25px;
+  }
+
+  .upload_button {
+    text-align: center;
+  }
+  .upload_button .primary-button {
+    margin-top: 20px;
+  }
+
+  .handle-instructions {
+    padding-bottom: 50px
+  }
+  .retrieving-invoice-spinner {
+    margin: 50px auto;
+  }
 }
 
 /* Extra Small Devices, Phones */


### PR DESCRIPTION
This hides the decorative images on small screens and compacts the layout to allow accurate spacing. It allows wrapping inside .choice-wrapper so that the sections inside wrap. It centers and reduces margins on spinners and buttons. This should make the site fully functional on small screens.