### PR TITLE
Binary encoded strings instead of trytes (merge/deploy with corresponding brokernode review)

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,5 +1,7 @@
 const IS_DEV = process.env.NODE_ENV === "development";
 
+const PROTOCOL = IS_DEV ? "http" : "https";
+
 const POLLING_NODE = IS_DEV
   ? ["52.14.218.135"] // QA broker
   : ["poll.oysternodes.com"];
@@ -22,8 +24,8 @@ const randBrokers = brokers => {
 const [ALPHA_IP, BETA_IP] = randBrokers(BROKERS);
 
 export const API = Object.freeze({
-  BROKER_NODE_A: `https://${ALPHA_IP}`,
-  BROKER_NODE_B: `https://${BETA_IP}`,
+  BROKER_NODE_A: `${PROTOCOL}://${ALPHA_IP}`,
+  BROKER_NODE_B: `${PROTOCOL}://${BETA_IP}`,
   V1_UPLOAD_SESSIONS_PATH: ":3000/api/v1/upload-sessions",
   V2_UPLOAD_SESSIONS_PATH: ":3000/api/v2/upload-sessions",
   GAS_PRICE: "https://api.blockcypher.com/v1/eth/main",
@@ -31,9 +33,9 @@ export const API = Object.freeze({
 });
 
 export const IOTA_API = Object.freeze({
-  PROVIDER_A: `https://${POLLING_NODE}:14265`,
-  PROVIDER_B: `https://${ALPHA_IP}:14265`,
-  PROVIDER_C: `https://${BETA_IP}:14265`,
+  PROVIDER_A: `${PROTOCOL}://${POLLING_NODE}:14265`,
+  PROVIDER_B: `${PROTOCOL}://${ALPHA_IP}:14265`,
+  PROVIDER_C: `${PROTOCOL}://${BETA_IP}:14265`,
   ADDRESS_LENGTH: 81,
   MESSAGE_LENGTH: 2187,
   BUNDLE_SIZE: 100

--- a/src/services/backend.js
+++ b/src/services/backend.js
@@ -56,7 +56,8 @@ const createUploadSession = (
         numChunks,
         genesisHash,
         betaIp: API.BROKER_NODE_B,
-        storageLengthInYears
+        storageLengthInYears,
+        version: FileProcessor.CURRENT_VERSION
       })
       .then(({ data }) => {
         const { id: alphaSessionId, betaSessionId } = data;

--- a/src/utils/file-processor.js
+++ b/src/utils/file-processor.js
@@ -153,5 +153,6 @@ export default {
   readBlob,
   fileSizeFromNumChunks,
   fileToChunks, // used just for testing.
-  chunksToFile
+  chunksToFile,
+  CURRENT_VERSION
 };

--- a/src/utils/file-processor.js
+++ b/src/utils/file-processor.js
@@ -97,12 +97,9 @@ const fileToChunks = (file, handle, opts = {}) =>
 
       Promise.all(chunks.map(readBlob)).then(arrayBuffer => {
         let encryptedChunks = arrayBuffer
-          .map(arrayBufferToString)
-          .map((binaryString, idx) =>
-            Encryption.encryptChunk(handleInBytes, idx + 1, binaryString)
+          .map((arrayBuffer, idx) =>
+            Encryption.encryptChunk(handleInBytes, idx + 1, arrayBuffer)
           )
-          .map(Iota.utils.toTrytes)
-          .map(Iota.addStopperTryte)
           .map((data, idx) => ({ idx: idx + 1, data })); // idx because things will get jumbled
 
         if (opts.withMeta) {
@@ -114,12 +111,9 @@ const fileToChunks = (file, handle, opts = {}) =>
           );
 
           const versionedMeta = addVersionToMeta(encryptedMeta);
-          const trytedMetaData = Iota.addStopperTryte(
-            Iota.utils.toTrytes(versionedMeta)
-          );
 
           encryptedChunks = [
-            { idx: 0, data: trytedMetaData },
+            { idx: 0, data: versionedMeta },
             ...encryptedChunks
           ];
         }
@@ -147,37 +141,11 @@ const chunksToFile = (chunks, handle) =>
         .map(data => Encryption.decryptChunk(handleInBytes, data))
         .join(""); // join removes nulls
 
-      resolve(new Blob([new Uint8Array(string2Bin(bytes))]));
+      resolve(new Blob([new Uint8Array(forge.util.binary.raw.decode(bytes))]));
     } catch (err) {
       reject(err);
     }
   });
-
-function arrayBufferToString(buffer) {
-  return binaryToString(
-    String.fromCharCode.apply(
-      null,
-      Array.prototype.slice.apply(new Uint8Array(buffer))
-    )
-  );
-}
-
-function binaryToString(binary) {
-  let error;
-
-  try {
-    return decodeURIComponent(escape(binary));
-  } catch (_error) {
-    error = _error;
-    if (error instanceof URIError) {
-      return binary;
-    } else {
-      throw error;
-    }
-  }
-}
-
-const string2Bin = str => _.map(str, c => c.charCodeAt(0));
 
 export default {
   metaDataFromIotaFormat,

--- a/src/utils/file-processor.test.js
+++ b/src/utils/file-processor.test.js
@@ -1,5 +1,6 @@
 import fs from "fs";
 import _ from "lodash";
+import Iota from "../services/iota";
 
 import FileProcessor from "./file-processor";
 
@@ -119,10 +120,12 @@ test("file |> fileToChunks |> chunksToFile - correct meta", done => {
   readTestFile().then(file => {
     FileProcessor.fileToChunks(file, handle, { withMeta: true })
       .then(encryptedChks => {
-        const metaChunk = encryptedChks[0];
+        const metaChunk = Iota.addStopperTryte(
+          Iota.utils.toTrytes(encryptedChks[0].data)
+        );
 
         const metaData = FileProcessor.metaDataFromIotaFormat(
-          metaChunk.data,
+          metaChunk,
           handle
         );
 


### PR DESCRIPTION
-Webinterface will now send binary encoded strings instead of trytes.  Make the broker do the tryting.
-Noticed some possible problems of having the broker rely on getting the version from the metadata chunk, which I described in the mainnet channel.  So for now I'm just sending this in the initial request to the broker, so it can be included in the upload_sessions table.  
-Detect whether we're in dev mode and use http if so.  
-Update metadata unit test