### PR TITLE
Meta state

### DIFF
--- a/cypress/integration/file-upload.js
+++ b/cypress/integration/file-upload.js
@@ -24,6 +24,10 @@ describe("Oyster file upload and download", () => {
         expect(path).to.eq("/payment-confirm");
       });
 
+      cy.location("pathname", { timeout: 60000 }).should(path => {
+        expect(path).to.eq("/upload-progress");
+      });
+
       // Success (60s timeout)
       cy.location("pathname", { timeout: 60000 }).should(path => {
         expect(path).to.eq("/upload-complete");

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "babel-preset-react-native": "^4.0.0",
     "babel-preset-stage-2": "^6.24.1",
     "cross-env": "^5.2.0",
-    "cypress": "^3.0.2",
+    "cypress": "^3.1.0",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "enzyme-to-json": "^3.3.3",

--- a/src/components/upload-progress/index.tsx
+++ b/src/components/upload-progress/index.tsx
@@ -21,9 +21,14 @@ class UploadProgress extends React.Component<
 > {
   render() {
     const { upload } = this.props;
-    const uploadProgress = upload.uploadProgress;
+    const { uploadProgress, uploadState } = upload;
 
-    return <UploadProgressSlide uploadProgress={uploadProgress} />;
+    return (
+      <UploadProgressSlide
+        uploadProgress={uploadProgress}
+        uploadState={uploadState}
+      />
+    );
   }
 }
 export default withRouter(

--- a/src/components/upload-progress/index.tsx
+++ b/src/components/upload-progress/index.tsx
@@ -1,13 +1,10 @@
 import React from "react";
 import { connect } from "react-redux";
 import { withRouter } from "react-router";
-import queryString from "query-string";
-import { streamUploadProgress } from "../../services/oyster-stream";
 
 import UploadProgressSlide from "./upload-progress-slide";
 import { getSortedHistoryDesc } from "../../redux/selectors/upload-history-selector";
 import uploadActions from "../../redux/actions/upload-actions";
-
 
 const mapStateToProps = state => ({
   upload: state.upload,
@@ -15,10 +12,10 @@ const mapStateToProps = state => ({
   historyDesc: getSortedHistoryDesc(state)
 });
 const mapDispatchToProps = dispatch => ({
-    streamUploadProgressFn: progress =>
-        dispatch(uploadActions.streamUploadProgress({progress})),
-    streamUploadSuccessFn: handle =>
-        dispatch(uploadActions.streamUploadSuccess({handle}))
+  streamUploadProgressFn: progress =>
+    dispatch(uploadActions.streamUploadProgress({ progress })),
+  streamUploadSuccessFn: handle =>
+    dispatch(uploadActions.streamUploadSuccess({ handle }))
 });
 
 interface UploadProgressProps {
@@ -34,38 +31,8 @@ interface UploadProgressState {}
 
 class UploadProgress extends React.Component<
   UploadProgressProps,
-  UploadProgressState> {
-
-  componentDidMount() {
-    const { location, streamUploadProgressFn, streamUploadSuccessFn } = this.props;
-    const query = queryString.parse(location.search);
-
-    if (query.handle) {
-      streamUploadProgress(query.handle, {
-        uploadProgressCb: (res) => {
-            const progress = res.progress;
-            streamUploadProgressFn(progress)
-        },
-        doneCb: (res) => {
-            const handle = res.handle;
-            streamUploadSuccessFn(handle)
-        },
-        errCb: (res) => {
-          console.log('Error Callback: ',res)
-
-            /**
-             * Temp code until brokers metadata upload timing is changed
-             */
-            setTimeout(() => {
-                window.location.reload();
-                alert("File not ready, attempting to refresh.")
-            }, 5000)
-
-        }
-      })
-    }
-  }
-
+  UploadProgressState
+> {
   render() {
     const { upload } = this.props;
     const uploadProgress = upload.uploadProgress;

--- a/src/components/upload-progress/index.tsx
+++ b/src/components/upload-progress/index.tsx
@@ -3,28 +3,14 @@ import { connect } from "react-redux";
 import { withRouter } from "react-router";
 
 import UploadProgressSlide from "./upload-progress-slide";
-import { getSortedHistoryDesc } from "../../redux/selectors/upload-history-selector";
-import uploadActions from "../../redux/actions/upload-actions";
 
 const mapStateToProps = state => ({
-  upload: state.upload,
-  uploadHistory: state.upload.history,
-  historyDesc: getSortedHistoryDesc(state)
+  upload: state.upload
 });
-const mapDispatchToProps = dispatch => ({
-  streamUploadProgressFn: progress =>
-    dispatch(uploadActions.streamUploadProgress({ progress })),
-  streamUploadSuccessFn: handle =>
-    dispatch(uploadActions.streamUploadSuccess({ handle }))
-});
+const mapDispatchToProps = dispatch => ({});
 
 interface UploadProgressProps {
   upload: any;
-  uploadHistory: any;
-  historyDesc: any[];
-  location: any;
-  streamUploadProgressFn: any;
-  streamUploadSuccessFn: any;
 }
 
 interface UploadProgressState {}

--- a/src/components/upload-progress/upload-progress-slide.tsx
+++ b/src/components/upload-progress/upload-progress-slide.tsx
@@ -1,13 +1,30 @@
 import React from "react";
 import { Line } from "rc-progress";
 
+import { UPLOAD_STATE } from "../../redux/reducers/upload-reducer";
 import Slide from "../shared/slide";
 import Spinner from "../shared/spinner";
 
 const ICON_UPLOAD = require("../../assets/images/icon_upload.png");
 
-const UploadProgressSlide = ({ uploadProgress }) => (
+const UploadProgressSlide = ({ uploadProgress, uploadState }) => (
   <Slide title="Upload Started" image={ICON_UPLOAD}>
+    {uploadState === UPLOAD_STATE.COMPLETE ? (
+      <div>
+        <strong className="transaction-confirmed-instructions">
+          File has been uploaded. You can check on the progress here:
+        </strong>
+        <br />
+        <a href={window.location.href}>{window.location.href}</a>
+      </div>
+    ) : (
+      <strong className="transaction-confirmed-instructions">
+        Please do not close this tab while your file is being uploaded.
+      </strong>
+    )}
+
+    <br />
+    <br />
     <p className="transaction-confirmed-instructions">
       Transaction Confirmed. Your file is now being uploaded to the Tangle.
       <Spinner isActive={uploadProgress === 0} className="download-spinner" />

--- a/src/redux/epics/navigation-epic.tsx
+++ b/src/redux/epics/navigation-epic.tsx
@@ -18,7 +18,7 @@ const goToUploadForm = (action$, store) => {
 
 const goToUploadStartedStream = (action$, store) => {
   return action$
-    .ofType(uploadActions.CHUNKS_DELIVERED)
+    .ofType(uploadActions.PAYMENT_CONFIRMED)
     .map(action => push("/upload-progress?handle=" + action.payload.handle));
 };
 

--- a/src/redux/epics/upload-epic.tsx
+++ b/src/redux/epics/upload-epic.tsx
@@ -1,6 +1,6 @@
 import { Observable } from "rxjs";
 import { combineEpics } from "redux-observable";
-import queryString from "query-string";
+// import queryString from "query-string";
 
 import uploadActions from "../actions/upload-actions";
 import { execObsverableIfBackendAvailable } from "./utils";

--- a/src/redux/epics/upload-epic.tsx
+++ b/src/redux/epics/upload-epic.tsx
@@ -3,7 +3,10 @@ import { combineEpics } from "redux-observable";
 
 import uploadActions from "../actions/upload-actions";
 import { execObsverableIfBackendAvailable } from "./utils";
-import { streamUpload } from "../../services/oyster-stream";
+import {
+  streamUpload,
+  streamUploadProgress
+} from "../../services/oyster-stream";
 import { alertUser } from "../../services/error-tracker";
 import { API } from "../../config";
 
@@ -34,10 +37,9 @@ const streamUploadEpic = action$ =>
               o.next(uploadActions.streamPaymentConfirmed(payload));
             },
 
-            chunksDeliveredCb: payload => {    
-                const handle = payload.handle;
-                console.log(handle);
-                o.next(uploadActions.streamChunksDelivered({ handle}));
+            chunksDeliveredCb: payload => {
+              const handle = payload.handle;
+              o.next(uploadActions.streamChunksDelivered({ handle }));
             },
 
             errCb: err => {
@@ -53,4 +55,25 @@ const streamUploadEpic = action$ =>
     );
   });
 
-export default combineEpics(streamUploadEpic);
+const streamUploadProgressEpic = action$ =>
+  action$.ofType(uploadActions.CHUNKS_DELIVERED).mergeMap(action => {
+    const { handle } = action.payload;
+
+    return Observable.create(o => {
+      streamUploadProgress(handle, {
+        uploadProgressCb: ({ progress }) => {
+          o.next(uploadActions.streamUploadProgress({ progress }));
+        },
+        doneCb: ({ handle }) => {
+          o.next(uploadActions.streamUploadSuccess({ handle }));
+          o.complete();
+        },
+        errCb: err => {
+          o.next(uploadActions.streamUploadError({ handle, err }));
+          o.complete();
+        }
+      });
+    });
+  });
+
+export default combineEpics(streamUploadEpic, streamUploadProgressEpic);

--- a/src/redux/epics/upload-epic.tsx
+++ b/src/redux/epics/upload-epic.tsx
@@ -60,39 +60,35 @@ const streamUploadProgressEpic = action$ =>
   action$.ofType(uploadActions.CHUNKS_DELIVERED).mergeMap(action => {
     const { handle } = action.payload;
 
-    return streamUploadProgressFn(handle);
-  });
-
-const streamUploadProgressRouteEpic = action$ =>
-  action$
-    .ofType("@@router/LOCATION_CHANGE")
-    .filter(action => action.payload.pathname === "/upload-progress")
-    .mergeMap(action => {
-      const { handle } = queryString.parse(action.payload.search);
-
-      return streamUploadProgressFn(handle);
-    });
-
-const streamUploadProgressFn = handle => {
-  return Observable.create(o => {
-    streamUploadProgress(handle, {
-      uploadProgressCb: ({ progress }) => {
-        o.next(uploadActions.streamUploadProgress({ progress }));
-      },
-      doneCb: ({ handle }) => {
-        o.next(uploadActions.streamUploadSuccess({ handle }));
-        o.complete();
-      },
-      errCb: err => {
-        o.next(uploadActions.streamUploadError({ handle, err }));
-        o.complete();
-      }
+    return Observable.create(o => {
+      streamUploadProgress(handle, {
+        uploadProgressCb: ({ progress }) => {
+          o.next(uploadActions.streamUploadProgress({ progress }));
+        },
+        doneCb: ({ handle }) => {
+          o.next(uploadActions.streamUploadSuccess({ handle }));
+          o.complete();
+        },
+        errCb: err => {
+          o.next(uploadActions.streamUploadError({ handle, err }));
+          o.complete();
+        }
+      });
     });
   });
-};
+
+// const streamUploadProgressRouteEpic = action$ =>
+//   action$
+//     .ofType("@@router/LOCATION_CHANGE")
+//     .filter(action => action.payload.pathname === "/upload-progress")
+//     .map(action => {
+//       const { handle } = queryString.parse(action.payload.search);
+
+//       return uploadActions.streamChunksDelivered({ handle });
+//     });
 
 export default combineEpics(
   streamUploadEpic,
-  streamUploadProgressEpic,
-  streamUploadProgressRouteEpic
+  streamUploadProgressEpic
+  // streamUploadProgressRouteEpic
 );

--- a/src/redux/epics/upload-epic.tsx
+++ b/src/redux/epics/upload-epic.tsx
@@ -77,18 +77,4 @@ const streamUploadProgressEpic = action$ =>
     });
   });
 
-// const streamUploadProgressRouteEpic = action$ =>
-//   action$
-//     .ofType("@@router/LOCATION_CHANGE")
-//     .filter(action => action.payload.pathname === "/upload-progress")
-//     .map(action => {
-//       const { handle } = queryString.parse(action.payload.search);
-
-//       return uploadActions.streamChunksDelivered({ handle });
-//     });
-
-export default combineEpics(
-  streamUploadEpic,
-  streamUploadProgressEpic
-  // streamUploadProgressRouteEpic
-);
+export default combineEpics(streamUploadEpic, streamUploadProgressEpic);

--- a/src/redux/reducers/upload-reducer.tsx
+++ b/src/redux/reducers/upload-reducer.tsx
@@ -1,5 +1,12 @@
 import uploadActions from "../actions/upload-actions";
+import navigationActions from "../actions/navigation-actions";
 import { API } from "../../config";
+
+export const UPLOAD_STATE = Object.freeze({
+  UPLOADING: "UPLOADING",
+  ATTACHING_META: "ATTACHING_META", // Upload complete, waiting for meta.
+  COMPLETE: "COMPLETE" // Attached meta, could be waiting for rest of chunks or completed.
+});
 
 const initState = {
   alphaBroker: API.BROKER_NODE_A,
@@ -11,11 +18,15 @@ const initState = {
   invoice: null, // { cost, ethAddress }
   gasPrice: 20,
   uploadProgress: 0,
-  handle: ""
+  handle: "",
+  uploadState: UPLOAD_STATE.UPLOADING
 };
 
 const uploadReducer = (state = initState, action) => {
   switch (action.type) {
+    case navigationActions.VISIT_UPLOAD_FORM:
+      return initState; // resets state.
+
     case uploadActions.SELECT_ALPHA_BROKER:
       return {
         ...state,
@@ -40,17 +51,26 @@ const uploadReducer = (state = initState, action) => {
       const { cost, ethAddress } = action.payload;
       return { ...state, invoice: { cost, ethAddress } };
 
+    case uploadActions.PAYMENT_CONFIRMED:
+      return { ...state, uploadState: UPLOAD_STATE.ATTACHING_META };
+
+    case uploadActions.CHUNKS_DELIVERED: {
+      const { handle } = action.payload;
+      return { ...state, handle, uploadState: UPLOAD_STATE.COMPLETE };
+    }
+
     case uploadActions.UPLOAD_PROGRESS:
       const { progress } = action.payload;
       return { ...state, uploadProgress: progress };
 
     // case uploadActions.UPLOAD:
-    // case uploadActions.PAYMENT_CONFIRMED:
     // case uploadActions.UPLOAD_ERROR:
 
-    case uploadActions.UPLOAD_SUCCESS:
-       const { handle } = action.payload;
-       return { ...state, handle: handle}
+    case uploadActions.UPLOAD_SUCCESS: {
+      const { handle } = action.payload;
+      return { ...state, handle: handle };
+    }
+
     default:
       return state;
   }

--- a/src/redux/reducers/upload-reducer.tsx
+++ b/src/redux/reducers/upload-reducer.tsx
@@ -63,9 +63,6 @@ const uploadReducer = (state = initState, action) => {
       const { progress } = action.payload;
       return { ...state, uploadProgress: progress };
 
-    // case uploadActions.UPLOAD:
-    // case uploadActions.UPLOAD_ERROR:
-
     case uploadActions.UPLOAD_SUCCESS: {
       const { handle } = action.payload;
       return { ...state, handle: handle };

--- a/yarn.lock
+++ b/yarn.lock
@@ -556,9 +556,9 @@ async-limiter@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
 
-async@2.1.4:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.1.4.tgz#2d2160c7788032e4dd6cbe2502f1f9a2c8f6cde4"
+async@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.4.0.tgz#4990200f18ea5b837c2cc4f8c031a6985c385611"
   dependencies:
     lodash "^4.14.0"
 
@@ -2725,9 +2725,9 @@ cyclist@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
 
-cypress@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-3.0.2.tgz#90caef84c91bd52b9cdf123aa76213249a289694"
+cypress@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-3.1.0.tgz#b718ba64289b887c7ab7a7f09245d871a4a409ba"
   dependencies:
     "@cypress/listr-verbose-renderer" "0.4.1"
     "@cypress/xvfb" "1.2.3"
@@ -2752,13 +2752,13 @@ cypress@^3.0.2:
     executable "4.1.1"
     extract-zip "1.6.6"
     fs-extra "4.0.1"
-    getos "2.8.4"
+    getos "3.1.0"
     glob "7.1.2"
     is-ci "1.0.10"
     is-installed-globally "0.1.0"
     lazy-ass "1.6.0"
     listr "0.12.0"
-    lodash "4.17.4"
+    lodash "4.17.10"
     log-symbols "2.2.0"
     minimist "1.2.0"
     progress "1.1.8"
@@ -4102,11 +4102,11 @@ get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
 
-getos@2.8.4:
-  version "2.8.4"
-  resolved "https://registry.yarnpkg.com/getos/-/getos-2.8.4.tgz#7b8603d3619c28e38cb0fe7a4f63c3acb80d5163"
+getos@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/getos/-/getos-3.1.0.tgz#db3aa4df15a3295557ce5e81aa9e3e5cdfaa6567"
   dependencies:
-    async "2.1.4"
+    async "2.4.0"
 
 getpass@^0.1.1:
   version "0.1.7"
@@ -5959,11 +5959,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@4.17.4:
-  version "4.17.4"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
-
-"lodash@>=3.5 <5", lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1:
+lodash@4.17.10, "lodash@>=3.5 <5", lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 


### PR DESCRIPTION
1. Refactors to move logic from view to epic
2. Adds extra test case for `/upload-progress` path
3. Adds text to differentiate when a user can close a tab

NOTE: Coming back to check on an upload's progress is still WIP. This PR is getting too big, so I thought this would be a good stopping point. The normal flow of uploading now has extra text to differentiate when waiting for meta to attach.