### PR TITLE
Brokers down splash page fix:  resolve as false when query fails

### DIFF
--- a/src/services/backend.tsx
+++ b/src/services/backend.tsx
@@ -24,7 +24,7 @@ const checkStatus = hosts =>
         resolve(available);
       })
       .catch(err => {
-        reject(err);
+        resolve(false);
       });
   });
 


### PR DESCRIPTION
When the `/status` check fails we should treat it as false.